### PR TITLE
Anonymize shop_subscription posts in addition to shop_order

### DIFF
--- a/includes/utilities.php
+++ b/includes/utilities.php
@@ -39,7 +39,7 @@ function get_orders( int $offset = 0 ): array {
 	global $wpdb;
 
 	return $wpdb->get_results(
-		$wpdb->prepare( "SELECT ID FROM {$wpdb->posts} WHERE post_type = 'shop_order' LIMIT 1000 OFFSET %d", $offset ), ARRAY_A
+		$wpdb->prepare( "SELECT ID FROM {$wpdb->posts} WHERE post_type = 'shop_order' OR post_type = 'shop_subscription' LIMIT 1000 OFFSET %d", $offset ), ARRAY_A
 	);
 }
 


### PR DESCRIPTION
#3

#### Changes proposed in this Pull Request

* Added `shop_subscription` to the query in the `get_orders` method. This will make it so subscriptions are anonymized.

#### Testing instructions

1. Go to WooCommerce > Subscriptions and add a new subscription
2. Go to Settings > Anonymizer and click the Anonymize Users
3. Confirm that the subscription you created has fake data now
