### PR TITLE
Disable Action Scheduler and update admin warning

### DIFF
--- a/includes/admin.php
+++ b/includes/admin.php
@@ -14,6 +14,8 @@ add_action( 'wp_ajax_safety_net_anonymize_users', __NAMESPACE__ . '\handle_ajax_
 add_action( 'wp_ajax_safety_net_scrub_options', __NAMESPACE__ . '\handle_ajax_scrub_options' );
 add_action( 'wp_ajax_safety_net_deactivate_plugins', __NAMESPACE__ . '\handle_ajax_deactivate_plugins' );
 add_action( 'wp_ajax_safety_net_delete_users', __NAMESPACE__ . '\handle_ajax_delete_users' );
+add_action( 'init', 'disable_action_scheduler', 10 );
+add_action( 'admin_notices', array( $this, 'show_warning' ) );
 add_filter( 'plugin_action_links_' . SAFETY_NET_BASENAME, __NAMESPACE__ . '\add_action_links' );
 
 /**
@@ -342,4 +344,31 @@ function add_action_links( $actions ) {
 	);
 
 	return array_merge( $actions, $links );
+}
+
+/**
+ * Unhook the Action Scheduler queue runner
+ *
+ */
+
+function disable_action_scheduler() {
+	if ( class_exists( 'ActionScheduler' ) ) {
+		remove_action( 'action_scheduler_run_queue', array( ActionScheduler::runner(), 'run' ) );
+	}
+}
+
+/**
+ * Display Warning that Safety Net is activated.
+ *
+ */
+public function show_warning() {
+	echo "\n<div class='notice notice-info'><p>";
+	echo '<strong>';
+		esc_html_e( 'Safety Net Activated', 'safety-net' );
+	echo ': ';
+	echo '</strong>';
+
+	esc_html_e( 'The Safety Net plugin is currently active, which will prevent any emails from being sent, and prevents Action Scheduler from running.  ', 'safety-net' );
+	esc_html_e( 'To send emails or enable the AS queue runner, deactivate the Safety Net plugin.', 'safety-net' );
+	echo '</p></div>';
 }

--- a/includes/classes/class-stop-emails-phpmailer.php
+++ b/includes/classes/class-stop-emails-phpmailer.php
@@ -74,7 +74,6 @@ class Stop_Emails {
 	 */
 	public function register_hooks() {
 		add_action( 'plugins_loaded', array( $this, 'replace_phpmailer' ) );
-		add_action( 'admin_notices', array( $this, 'show_warning' ) );
 
 		/**
 		 * Force BuddyPress to use wp_mail() rather than its own BP_PHPMailer class
@@ -99,22 +98,6 @@ class Stop_Emails {
 		$obj = new Stop_Emails_Fake_PHPMailer();
 
 		return $obj;
-	}
-
-	/**
-	 * Display Warning that emails are being stopped.
-	 *
-	 */
-	public function show_warning() {
-		echo "\n<div class='notice notice-info'><p>";
-		echo '<strong>';
-			esc_html_e( 'Emails Disabled', 'safety-net' );
-		echo ': ';
-		echo '</strong>';
-
-		esc_html_e( 'The Safety Net plugin is currently active, which will prevent any emails from being sent.  ', 'safety-net' );
-		esc_html_e( 'To send emails, disable the plugin.', 'safety-net' );
-		echo '</p></div>';
 	}
 
 }


### PR DESCRIPTION
As the title says.

As some future point, we can consider making Action Scheduler toggleable, but for now we can just turn it off.