### PR TITLE
Flush the cache when anonymizing is complete

### DIFF
--- a/includes/classes/background-anonymize-customer.php
+++ b/includes/classes/background-anonymize-customer.php
@@ -40,5 +40,12 @@ class Background_Anonymize_Customer extends \WP_Background_Process {
 		return $item;
 	}
 
+	/**
+	 * When all customers have been anonymized, flush the cache.
+	 */
+	protected function complete() {
+		wp_cache_flush();
+	}
+
 }
 

--- a/includes/classes/background-anonymize-order.php
+++ b/includes/classes/background-anonymize-order.php
@@ -40,5 +40,12 @@ class Background_Anonymize_Order extends \WP_Background_Process {
 		return $item;
 	}
 
+	/**
+	 * When all orders have been anonymized, flush the cache.
+	 */
+	protected function complete() {
+		wp_cache_flush();
+	}
+
 }
 

--- a/includes/classes/background-anonymize-user.php
+++ b/includes/classes/background-anonymize-user.php
@@ -55,6 +55,9 @@ class Background_Anonymize_User extends \WP_Background_Process {
 		$wpdb->query( "DROP TABLE {$wpdb->users}_temp" );
 		$wpdb->query( "INSERT INTO $wpdb->usermeta (SELECT * FROM {$wpdb->usermeta}_temp WHERE user_id NOT IN (SELECT user_id FROM $wpdb->usermeta))" );
 		$wpdb->query( "DROP TABLE {$wpdb->usermeta}_temp" );
+
+		// Flush the cache.
+		wp_cache_flush();
 	}
 
 }


### PR DESCRIPTION
### Description
User data was still visible even after being anonymized. This is because it's stored in object cache.

### Changes proposed in this Pull Request

* Flushes the cache when each anonymization process is complete (orders, users, customers)

### Testing instructions
* Run Safety Net on Pressable
* View a subscription
* Confirm that the customer information is anonymized

Fixes #35 
