### PR TITLE
Add CLI commands for scrubbing options and disabling plugins

### DIFF
--- a/includes/cli/anonymize.php
+++ b/includes/cli/anonymize.php
@@ -85,7 +85,7 @@ class SafetyNet_CLI extends WP_CLI_Command {
 	}
 
 	/**
-	 * Clear options such as API keys so that plugins won't talk to 3rd parties
+	 * Deactivate problematic plugins from a denylist
 	 *
 	 * ## EXAMPLES
 	 *


### PR DESCRIPTION
Adds two new CLI commands:

`wp safety-net scrub-options` will clear options such as API keys so that plugins won't talk to 3rd parties

`wp safety-net deactivate-plugins` will deactivate problematic plugins from a denylist

Closes #25, closes #26 