### PR TITLE
Prevent search engine indexation

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,16 +8,16 @@ This is a WordPress plugin developed by WordPress.com Special Projects (Team 51)
 ## Existing Features
 - **Stop Emails**: When Safety Net is activated, WordPress will be blocked from sending emails. (Caution: may not block SMTP or other plugins from doing so). 
 - **Disable Action Scheduler**: When Safety Net is activated, the default queue runner for Action Scheduler is unhooked. This means that WooCommerce Subscriptions renewals, for example, will not be triggered at all. 
+- **Discourage search engines**: Sets the "Discourage search engines" option and disallows all user agents in the `robots.txt` file.
 - **Scrub Options**: Clears specific denylisted options, such as API keys, which could cause problems on a development site.
 - **Deactivate Plugins**: Deactivates denylisted plugins. Also, runs through installed Woo payment gateways and deactivates them as well (deactivates the actual plugin, not from the checkout settings).
+- **Delete**: Deletes all non-admin users, WooCommerce orders and subscriptions.
 - **Anonymize**: Replaces all non-admin user data with fake data. Works on the user table, WooCommerce orders and subscriptions. Also detaches individual subscriptions from their payment methods. Runs as a background process to handle large sites.
 
 #### Advanced features
-- **Delete**: Deletes users, WooCommerce Orders and WooCommerce Subscriptions from the site.
-- **CLI commands**: CLI equivalents of the above two features: `wp safety-net anonymize` and `wp safety-net delete`
+- **CLI commands**: CLI equivalents of the above features: `wp safety-net scrub-options`, `wp safety-net deactivate-plugins`, `wp safety-net anonymize` and `wp safety-net delete`
 
 ## Planned Features
-- The ability to pull in the denylisted plugins and options from a location that is more easily editable than a hardcoded array
 - Multi-site (WordPress network) compatibility
 - Add admin toggle to turn Action Scheduler and/or WP-Cron on and off.
 - Do you have a suggestion for the next great feature to add? Please create an issue or submit a PR!
@@ -32,6 +32,7 @@ Activating the plugin on a non-production site will:
 3. Delete users, orders, and subscriptions.*
 4. Stop emails. You can still test and view emails by activating the [WP Mail Logging plugin](https://wordpress.org/plugins/wp-mail-logging/). 
 5. Deactivate Action Scheduler. If you need to test anything that requires Action Scheduler, you will probably need to deactivate Safety Net.
+6. Discourage search engines.
 
 *Only runs automatically if `wp_get_environment_type` returns `staging`, `development`, or `local`. If that environment variable is not set for your site, you can also visit **Tools > Safety Net** and manually click the buttons in the Tools section to perform these actions.
 
@@ -50,5 +51,5 @@ You'll need to go into the `includes/bootstrap.php` file and comment out whichev
 ```php
 add_action( 'safety_net_loaded', __NAMESPACE__ . '\maybe_scrub_options' );
 add_action( 'safety_net_loaded', __NAMESPACE__ . '\maybe_deactivate_plugins' );
-add_action( 'safety_net_loaded', __NAMESPACE__ . '\maybe_anonymize_data' )
+add_action( 'safety_net_loaded', __NAMESPACE__ . '\maybe_delete_data' )
 ```

--- a/includes/common.php
+++ b/includes/common.php
@@ -5,7 +5,7 @@ namespace SafetyNet\Common;
 add_filter( 'send_password_change_email', '__return_false' );
 add_filter( 'send_email_change_email', '__return_false' );
 
-// Discourage search engines from indexing the site and disalow the entire site in robots.txt.
+// Discourage search engines from indexing the site and disallow the entire site in robots.txt.
 add_filter( 'option_blog_public', '__return_zero' );
 add_action( 'robots_txt', __NAMESPACE__ . '\disallow_all_user_agents' );
 

--- a/safety-net.php
+++ b/safety-net.php
@@ -1,7 +1,7 @@
 <?php
 /*
  * Plugin Name: Safety Net
- * Description: For Team51 Development Sites. Anonymizes user data and more!
+ * Description: For Team51 Development Sites. Deletes user data and more!
  * Version: 1.0.0-beta.3
  * Author: WordPress.com Special Projects
  * Author URI: https://wpspecialprojects.wordpress.com


### PR DESCRIPTION
Related to #30 

## Issue

As suggested in [Slack here](https://a8c.slack.com/archives/C01M1J49Q75/p1658513811579479), it would be a good idea to auto-check the "**Discourage search engines**" checkbox in the WordPress **Settings > Reading** section to make sure that sites with the "Safety Net" plugin active aren't indexed by the search engines.

## Suggested fix

I suggest to use the `option_blog_public` filter to change the value of that option on-the-fly. This would have the same practical results as changing that option in the database, but would avoid the unnecessary DB update.

I also think that it would be a good idea to modify the `robots.txt` file (using the `robots_txt` hook) to make sure that the entire site is disallowed from search agents. 

These are the contents that would appear in the `robots.txt` file once **Safety Net** is active:

```
User-agent: *
Disallow: /wp-admin/
Allow: /wp-admin/admin-ajax.php
```

## Note

I've added these lines of code to the `SafetyNet\Common` file since it seems the proper place to add this generic and small functionality. If you think that it should be added somewhere else (or create a new file for these features), just let me know! 