### PR TITLE
Optimizing deletion

### DIFF
--- a/includes/delete.php
+++ b/includes/delete.php
@@ -37,11 +37,11 @@ function delete_users_and_orders() {
 	reassign_all_posts();
 
 	$admins          = get_admin_user_ids();
-	$adminListString = implode( ",", $admins );
+	$admin_list_string = implode( ",", $admins );
 
 	// Delete all non-admin users and their usermeta
-	$wpdb->query( "DELETE FROM $wpdb->usermeta WHERE user_id NOT IN ( $adminListString )" );
-	$wpdb->query( "DELETE FROM $wpdb->users WHERE ID NOT IN ( $adminListString )" );
+	$wpdb->query( "DELETE FROM $wpdb->usermeta WHERE user_id NOT IN ( $admin_list_string )" );
+	$wpdb->query( "DELETE FROM $wpdb->users WHERE ID NOT IN ( $admin_list_string )" );
 
 	// Set option so this function doesn't run again.
 	update_option( 'safety_net_data_deleted', true );

--- a/includes/delete.php
+++ b/includes/delete.php
@@ -33,24 +33,15 @@ function delete_users_and_orders() {
 	$wpdb->query( "DELETE FROM $wpdb->posts WHERE post_type = 'shop_order'" );
 	$wpdb->query( "DELETE FROM $wpdb->posts WHERE post_type = 'shop_subscription'" );
 
-	// reassigning all posts to the first admin user
+	// Reassigning all posts to the first admin user
 	reassign_all_posts();
 
-	$users  = $wpdb->get_results( "SELECT ID FROM $wpdb->users ORDER BY ID" );
-	$admins = get_admin_user_ids();
+	$admins          = get_admin_user_ids();
+	$adminListString = implode( ",", $admins );
 
-	foreach ( $users as $user ) {
-		// Skip administrators.
-		if ( in_array( $user->ID, $admins, true ) ) {
-			continue;
-		}
-
-		// Get all of their meta and delete it.
-		delete_all_users_meta( $user->ID );
-
-		// Delete the user.
-		$wpdb->delete( $wpdb->users, array( 'ID' => $user->ID ) );
-	}
+	// Delete all non-admin users and their usermeta
+	$wpdb->query( "DELETE FROM $wpdb->usermeta WHERE user_id NOT IN ( $adminListString )" );
+	$wpdb->query( "DELETE FROM $wpdb->users WHERE ID NOT IN ( $adminListString )" );
 
 	// Set option so this function doesn't run again.
 	update_option( 'safety_net_data_deleted', true );

--- a/safety-net.php
+++ b/safety-net.php
@@ -9,23 +9,8 @@
  * License: GPLv3
 */
 
-if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Exit if accessed directly
-}
-
-// Protect against more than one copy of the plugin being activated
-if ( defined( 'SAFETY_NET_PATH' ) ) {
-	require_once ABSPATH . 'wp-admin/includes/plugin.php';
-	deactivate_plugins( plugin_basename( __FILE__ ) );
-
-	function deactivation_admin_notice() {
-		$class   = 'notice notice-error';
-		$message = __( 'It looks like more than one copy of Safety Net is installed, so one has been deactivated.', 'safety-net' );
-		printf( '<div class="%1$s"><p>%2$s</p></div>', esc_attr( $class ), esc_html( $message ) );
-	}
-	add_action( 'admin_notices', 'deactivation_admin_notice' );
-
-	return;
+if ( ! defined( 'ABSPATH' ) || defined( 'SAFETY_NET_PATH' ) ) {
+	exit; // Exit if accessed directly or if another copy of the plugin is activated
 }
 
 define( 'SAFETY_NET_PATH', plugin_dir_path( __FILE__ ) );


### PR DESCRIPTION
Removed `foreach` loop for deleting users, and changed it to two lines:

```php
	$wpdb->query( "DELETE FROM $wpdb->usermeta WHERE user_id NOT IN ( $adminListString )" );
	$wpdb->query( "DELETE FROM $wpdb->users WHERE ID NOT IN ( $adminListString )" );
```

Tested out, and it deletes 60k users in 9 seconds. This is a huge upgrade in performance.