### PR TITLE
Add a filter to hide/disable the admin controls 

### DIFF
--- a/includes/admin.php
+++ b/includes/admin.php
@@ -17,20 +17,19 @@ add_filter( 'init', __NAMESPACE__ . '\add_admin_hooks' );
  */
 function add_admin_hooks(){
 
-	if ( true === apply_filters( 'safety_net_hide_admin', false ) ) {
-		return;
+	if ( true !== apply_filters( 'safety_net_hide_admin', false ) ) {
+		// Skip the admin page and options if the `safety_net_hide_admin` filter returns true.
+		add_action( 'admin_enqueue_scripts', __NAMESPACE__ . '\enqueue_scripts' );
+		add_action( 'admin_menu', __NAMESPACE__ . '\create_options_menu' );
+		add_action( 'admin_init', __NAMESPACE__ . '\settings_init' );
+		add_action( 'wp_ajax_safety_net_anonymize_users', __NAMESPACE__ . '\handle_ajax_anonymize_users' );
+		add_action( 'wp_ajax_safety_net_scrub_options', __NAMESPACE__ . '\handle_ajax_scrub_options' );
+		add_action( 'wp_ajax_safety_net_deactivate_plugins', __NAMESPACE__ . '\handle_ajax_deactivate_plugins' );
+		add_action( 'wp_ajax_safety_net_delete_users', __NAMESPACE__ . '\handle_ajax_delete_users' );
+		add_filter( 'plugin_action_links_' . SAFETY_NET_BASENAME, __NAMESPACE__ . '\add_action_links' );
 	}
-
-	add_action( 'admin_enqueue_scripts', __NAMESPACE__ . '\enqueue_scripts' );
-	add_action( 'admin_menu', __NAMESPACE__ . '\create_options_menu' );
-	add_action( 'admin_init', __NAMESPACE__ . '\settings_init' );
-	add_action( 'wp_ajax_safety_net_anonymize_users', __NAMESPACE__ . '\handle_ajax_anonymize_users' );
-	add_action( 'wp_ajax_safety_net_scrub_options', __NAMESPACE__ . '\handle_ajax_scrub_options' );
-	add_action( 'wp_ajax_safety_net_deactivate_plugins', __NAMESPACE__ . '\handle_ajax_deactivate_plugins' );
-	add_action( 'wp_ajax_safety_net_delete_users', __NAMESPACE__ . '\handle_ajax_delete_users' );
 	add_action( 'action_scheduler_pre_init', __NAMESPACE__ . '\pause_renewal_actions' );
 	add_action( 'admin_notices', __NAMESPACE__ . '\show_warning' );
-	add_filter( 'plugin_action_links_' . SAFETY_NET_BASENAME, __NAMESPACE__ . '\add_action_links' );
 	add_filter( 'wp_mail', __NAMESPACE__ . '\stop_emails', 10, 1 );
 }
 

--- a/includes/admin.php
+++ b/includes/admin.php
@@ -8,17 +8,26 @@ use function SafetyNet\DeactivatePlugins\deactivate_plugins;
 use function SafetyNet\Delete\delete_users_and_orders;
 use function SafetyNet\Utilities\is_production;
 
-add_action( 'admin_enqueue_scripts', __NAMESPACE__ . '\enqueue_scripts' );
-add_action( 'admin_menu', __NAMESPACE__ . '\create_options_menu' );
-add_action( 'admin_init', __NAMESPACE__ . '\settings_init' );
-add_action( 'wp_ajax_safety_net_anonymize_users', __NAMESPACE__ . '\handle_ajax_anonymize_users' );
-add_action( 'wp_ajax_safety_net_scrub_options', __NAMESPACE__ . '\handle_ajax_scrub_options' );
-add_action( 'wp_ajax_safety_net_deactivate_plugins', __NAMESPACE__ . '\handle_ajax_deactivate_plugins' );
-add_action( 'wp_ajax_safety_net_delete_users', __NAMESPACE__ . '\handle_ajax_delete_users' );
-add_action( 'action_scheduler_pre_init', __NAMESPACE__ . '\pause_renewal_actions' );
-add_action( 'admin_notices', __NAMESPACE__ . '\show_warning' );
-add_filter( 'plugin_action_links_' . SAFETY_NET_BASENAME, __NAMESPACE__ . '\add_action_links' );
-add_filter( 'wp_mail', __NAMESPACE__ . '\stop_emails', 10, 1 );
+add_filter( 'init', __NAMESPACE__ . '\add_admin_hooks' );
+
+/**
+ * Registers all the admin hooks.
+ *
+ * @return void
+ */
+function add_admin_hooks(){
+	add_action( 'admin_enqueue_scripts', __NAMESPACE__ . '\enqueue_scripts' );
+	add_action( 'admin_menu', __NAMESPACE__ . '\create_options_menu' );
+	add_action( 'admin_init', __NAMESPACE__ . '\settings_init' );
+	add_action( 'wp_ajax_safety_net_anonymize_users', __NAMESPACE__ . '\handle_ajax_anonymize_users' );
+	add_action( 'wp_ajax_safety_net_scrub_options', __NAMESPACE__ . '\handle_ajax_scrub_options' );
+	add_action( 'wp_ajax_safety_net_deactivate_plugins', __NAMESPACE__ . '\handle_ajax_deactivate_plugins' );
+	add_action( 'wp_ajax_safety_net_delete_users', __NAMESPACE__ . '\handle_ajax_delete_users' );
+	add_action( 'action_scheduler_pre_init', __NAMESPACE__ . '\pause_renewal_actions' );
+	add_action( 'admin_notices', __NAMESPACE__ . '\show_warning' );
+	add_filter( 'plugin_action_links_' . SAFETY_NET_BASENAME, __NAMESPACE__ . '\add_action_links' );
+	add_filter( 'wp_mail', __NAMESPACE__ . '\stop_emails', 10, 1 );
+}
 
 /**
  * Enqueues the JavaScript for the tools page.

--- a/includes/admin.php
+++ b/includes/admin.php
@@ -16,6 +16,11 @@ add_filter( 'init', __NAMESPACE__ . '\add_admin_hooks' );
  * @return void
  */
 function add_admin_hooks(){
+
+	if ( true === apply_filters( 'safety_net_hide_admin', false ) ) {
+		return;
+	}
+
 	add_action( 'admin_enqueue_scripts', __NAMESPACE__ . '\enqueue_scripts' );
 	add_action( 'admin_menu', __NAMESPACE__ . '\create_options_menu' );
 	add_action( 'admin_init', __NAMESPACE__ . '\settings_init' );


### PR DESCRIPTION
### Description

As detailed in #43, it would be nice to be able to hide the Safety Net admin page (Tools > Safety Net) using a filter. This way, any developer (or us) could disable it easily by using the following code:

`add_filter( 'safety_net_hide_admin', '__return_true' );`

