### PR TITLE
Use pre_wp_mail

### DIFF
--- a/includes/admin.php
+++ b/includes/admin.php
@@ -403,15 +403,15 @@ function show_warning() {
  *
  */
 function stop_emails( $return, $args ) {
-	if (! strstr( $args['subject'], 'Password Reset Request' ) ) {
-		error_log( "Email blocked: " . $args['subject'] );
+	if ( ! strstr( $args['subject'], 'Password Reset Request' ) ) {
+		error_log( "Email blocked: " . $args['subject'] ); // phpcs:ignore -- Logging is okay here.
 		// returning false says "short-circuit the wp_mail() function and indicate we did not send the email"
 		$return = false;
 	} else {
-		error_log( "Email sent: " . $args['subject'] );
+		error_log( "Email sent: " . $args['subject'] ); // phpcs:ignore -- Logging is okay here.
 		// returning null says "don't short circuit the wp_mail function"
 		$return = null;
 	}
 
-    return $return;
-};
+	return $return;
+}

--- a/includes/admin.php
+++ b/includes/admin.php
@@ -403,7 +403,7 @@ function show_warning() {
  *
  */
 function stop_emails( $return, $args ) {
-	if ( ! strstr( $args['subject'], 'Password Reset Request' ) ) {
+	if ( ! strstr( $args['subject'], 'Password Reset' ) ) {
 		error_log( "Email blocked: " . $args['subject'] ); // phpcs:ignore -- Logging is okay here.
 		// returning false says "short-circuit the wp_mail() function and indicate we did not send the email"
 		$return = false;

--- a/includes/admin.php
+++ b/includes/admin.php
@@ -18,7 +18,7 @@ add_action( 'wp_ajax_safety_net_delete_users', __NAMESPACE__ . '\handle_ajax_del
 add_action( 'action_scheduler_pre_init', __NAMESPACE__ . '\pause_renewal_actions' );
 add_action( 'admin_notices', __NAMESPACE__ . '\show_warning' );
 add_filter( 'plugin_action_links_' . SAFETY_NET_BASENAME, __NAMESPACE__ . '\add_action_links' );
-add_filter( 'wp_mail', __NAMESPACE__ . '\stop_emails', 10, 1 );
+add_filter( 'pre_wp_mail', __NAMESPACE__ . '\stop_emails', 10, 2 );
 
 /**
  * Enqueues the JavaScript for the tools page.
@@ -402,9 +402,16 @@ function show_warning() {
  * Stop all emails except password resets
  *
  */
-function stop_emails( $args ) {
+function stop_emails( $return, $args ) {
 	if (! strstr( $args['subject'], 'Password Reset Request' ) ) {
-		unset ( $args['to'] );
+		error_log( "Email blocked: " . $args['subject'] );
+		// returning false says "short-circuit the wp_mail() function and indicate we did not send the email"
+		$return = false;
+	} else {
+		error_log( "Email sent: " . $args['subject'] );
+		// returning null says "don't short circuit the wp_mail function"
+		$return = null;
 	}
-    return $args;
+
+    return $return;
 };

--- a/includes/deactivate-plugins.php
+++ b/includes/deactivate-plugins.php
@@ -74,6 +74,8 @@ function deactivate_plugins() {
 */
 function scrub_options() {
 
+	update_option( 'admin_email', 'safetynet@scrubbedthis.option' );
+
 	$options_to_clear = get_denylist_array( 'options' );
 	$options_to_clear = apply_filters( 'safety_net_options_to_clear', $options_to_clear );
 

--- a/safety-net.php
+++ b/safety-net.php
@@ -2,7 +2,7 @@
 /*
  * Plugin Name: Safety Net
  * Description: For Team51 Development Sites. Deletes user data and more!
- * Version: 1.4.0
+ * Version: 1.4.1
  * Author: WordPress.com Special Projects
  * Author URI: https://wpspecialprojects.wordpress.com
  * Text Domain: safety-net


### PR DESCRIPTION
Now using `pre_wp_mail` to short circuit `wp_mail` entirely.