### PR TITLE
Use namespace to prevent fatal error

### DIFF
--- a/includes/admin.php
+++ b/includes/admin.php
@@ -371,7 +371,7 @@ function pause_renewal_actions() {
 	if ( 'on' === get_option( 'safety_net_pause_renewal_actions_toggle' ) ) {
 		require_once __DIR__ . '/classes/class-actionscheduler-custom-dbstore.php';
 		add_filter( 'action_scheduler_store_class', function( $class ) {
-			return 'ActionScheduler_Custom_DBStore';
+			return 'SafetyNet\ActionScheduler_Custom_DBStore';
 		}, 101, 1 );
 	}
 }

--- a/includes/classes/class-actionscheduler-custom-dbstore.php
+++ b/includes/classes/class-actionscheduler-custom-dbstore.php
@@ -1,6 +1,8 @@
 <?php
 
-class ActionScheduler_Custom_DBStore extends ActionScheduler_DBStore {
+namespace SafetyNet;
+
+class ActionScheduler_Custom_DBStore extends \ActionScheduler_DBStore {
 
 	protected function claim_actions( $claim_id, $limit, \DateTime $before_date = null, $hooks = array(), $group = '' ) {
 


### PR DESCRIPTION
This PR adds a namespace to the `ActionScheduler_Custom_DBStore` class to prevent the fatal error when the Pause Renewal Actions plugin is installed and active.

Tested and the fatal error no longer happens. But further testing to make sure renewals are actually paused is still needed.

Some other ideas I tested that we may want to consider:

1. Disabling the Pause Renewal Actions plugin when Safety Net is installed? We would want to make sure that if we go this route, we enable the "Pause Renewals" option in Safety Net if it was enabled in the other plugin.
2.  Check if `pause_renewal_actions_toggle` option is `on` and don't include our file if true. That option is being used by the other plugin. The downside is if that option changes in the future, we may get a fatal error again.

#74 