### PR TITLE
Fix/55 Fix anonymize functionality from CLI

### DIFF
--- a/includes/admin.php
+++ b/includes/admin.php
@@ -44,7 +44,8 @@ function enqueue_scripts( string $hook_suffix ) {
 		return;
 	}
 
-	wp_enqueue_script( 'safety-net-admin', SAFETY_NET_URL . 'assets/js/safety-net-admin.js', array( 'jquery' ), '1.0', true );
+	$admin_script_path = SAFETY_NET_URL . 'assets/js/safety-net-admin.js';
+	wp_enqueue_script( 'safety-net-admin', $admin_script_path, array( 'jquery' ), filemtime( $admin_script_path ), true );
 
 	wp_localize_script(
 		'safety-net-admin',

--- a/includes/admin.php
+++ b/includes/admin.php
@@ -15,14 +15,13 @@ add_filter( 'init', __NAMESPACE__ . '\add_admin_hooks' );
  *
  * @return void
  */
-function add_admin_hooks(){
+function add_admin_hooks() {
 
 	if ( true !== apply_filters( 'safety_net_hide_admin', false ) ) {
 		// Skip the admin page and options if the `safety_net_hide_admin` filter returns true.
 		add_action( 'admin_enqueue_scripts', __NAMESPACE__ . '\enqueue_scripts' );
 		add_action( 'admin_menu', __NAMESPACE__ . '\create_options_menu' );
 		add_action( 'admin_init', __NAMESPACE__ . '\settings_init' );
-		add_action( 'wp_ajax_safety_net_anonymize_users', __NAMESPACE__ . '\handle_ajax_anonymize_users' );
 		add_action( 'wp_ajax_safety_net_scrub_options', __NAMESPACE__ . '\handle_ajax_scrub_options' );
 		add_action( 'wp_ajax_safety_net_deactivate_plugins', __NAMESPACE__ . '\handle_ajax_deactivate_plugins' );
 		add_action( 'wp_ajax_safety_net_delete_users', __NAMESPACE__ . '\handle_ajax_delete_users' );
@@ -45,14 +44,14 @@ function enqueue_scripts( string $hook_suffix ) {
 		return;
 	}
 
-	wp_enqueue_script( 'safety-net-admin', SAFETY_NET_URL . 'assets/js/safety-net-admin.js', [ 'jquery' ], '1.0', true );
+	wp_enqueue_script( 'safety-net-admin', SAFETY_NET_URL . 'assets/js/safety-net-admin.js', array( 'jquery' ), '1.0', true );
 
 	wp_localize_script(
 		'safety-net-admin',
 		'safety_net_params',
-		[
+		array(
 			'ajax_url' => admin_url( 'admin-ajax.php' ),
-		]
+		)
 	);
 
 	wp_enqueue_style( 'safety-net-admin-style', SAFETY_NET_URL . 'assets/css/admin.css', array(), '0.0' );
@@ -100,12 +99,12 @@ function settings_init() {
 		__NAMESPACE__ . '\render_field',
 		'safety_net_options',
 		'safety_net_option',
-		[
-			'type' => 'button',
-			'id' => 'safety-net-scrub-options',
+		array(
+			'type'        => 'button',
+			'id'          => 'safety-net-scrub-options',
 			'button_text' => esc_html__( 'Scrub Options', 'safety-net' ),
 			'description' => esc_html__( 'Clears specific denylisted options, such as API keys, which could cause problems on a development site.', 'safety-net' ),
-		]
+		)
 	);
 
 	add_settings_field(
@@ -114,12 +113,12 @@ function settings_init() {
 		__NAMESPACE__ . '\render_field',
 		'safety_net_options',
 		'safety_net_option',
-		[
-			'type' => 'button',
-			'id' => 'safety-net-deactivate-plugins',
+		array(
+			'type'        => 'button',
+			'id'          => 'safety-net-deactivate-plugins',
 			'button_text' => esc_html__( 'Deactivate Plugins', 'safety-net' ),
 			'description' => esc_html__( 'Deactivates a handful of denylisted plugins. Also, runs through installed Woo payment gateways and deactivates them (deactivates the actual plugin, not from the checkout settings).', 'safety-net' ),
-		]
+		)
 	);
 
 	add_settings_field(
@@ -128,12 +127,12 @@ function settings_init() {
 		__NAMESPACE__ . '\render_field',
 		'safety_net_options',
 		'safety_net_option',
-		[
-			'type' => 'button',
-			'id' => 'safety-net-delete-users',
+		array(
+			'type'        => 'button',
+			'id'          => 'safety-net-delete-users',
 			'button_text' => esc_html__( 'Delete', 'safety-net' ),
 			'description' => esc_html__( 'Deletes all non-admin users, as well as WooCommerce orders and subscriptions.', 'safety-net' ),
-		]
+		)
 	);
 
 	add_settings_field(
@@ -158,27 +157,29 @@ function settings_init() {
  *
  * @return void
  */
-function render_field( array $args = [] ) {
+function render_field( array $args = array() ) {
 	if ( ! isset( $args['type'] ) ) {
 		return;
 	} ?>
 
-	<?php if ( 'checkbox' === $args['type'] ) : 
+	<?php
+	if ( 'checkbox' === $args['type'] ) :
 		$checked = '';
 		if ( 'on' === get_option( $args['name'] ) ) {
-			$checked = ' checked="checked" '; 
-		} ?>
-		<input id="<?php echo esc_attr( $args['name'] ) ?>" class="<?php echo esc_attr( $args['class'] ) ?>" name="<?php echo esc_attr( $args['name'] ) ?>" type="checkbox" <?php echo $checked ?> />
+			$checked = ' checked="checked" ';
+		}
+		?>
+		<input id="<?php echo esc_attr( $args['name'] ); ?>" class="<?php echo esc_attr( $args['class'] ); ?>" name="<?php echo esc_attr( $args['name'] ); ?>" type="checkbox" <?php echo $checked; ?> />
 	<?php endif; ?>
 
 	<?php if ( 'button' === $args['type'] ) : ?>
 		<button type="button" id="<?php echo esc_attr( $args['id'] ); ?>" class="button button-large" data-nonce="<?php echo wp_create_nonce( $args['id'] ); ?>">
-			<?php echo esc_html( $args['button_text' ] ) ?>
+			<?php echo esc_html( $args['button_text'] ); ?>
 		</button>
 	<?php endif; ?>
 
-	<?php if ( isset( $args['description' ] ) ) : ?>
-		<p class="description" id="tagline-description"><?php echo esc_html( $args['description' ] ); ?></p>
+	<?php if ( isset( $args['description'] ) ) : ?>
+		<p class="description" id="tagline-description"><?php echo esc_html( $args['description'] ); ?></p>
 	<?php endif; ?>
 	<?php
 }
@@ -205,12 +206,14 @@ function render_options_html() {
 		<form action="options.php" method="post">
 			<?php
 			settings_fields( 'safety-net' );
-			do_settings_sections( 'safety_net_options' ); ?>
+			do_settings_sections( 'safety_net_options' );
+			?>
 			<input name="Submit" type="submit" class="button button-primary safety-net-save" value="<?php esc_attr_e( 'Save Changes' ); ?>" />
 		</form>
 	</div>
 	<div class="loading-overlay"></div>
-	<?php }
+	<?php
+}
 }
 
 /**
@@ -224,27 +227,27 @@ function handle_ajax_scrub_options() {
 	if ( is_production() ) {
 		// Send an AJAX warning.
 		echo json_encode(
-			[
+			array(
 				'warning' => true,
 				'message' => esc_html__( 'You can not run these tools on a production site. Please set the environment type correctly.' ),
-			]
+			)
 		);
 		die();
 	}
 
 	// Permissions and security checks.
 	check_the_permissions();
-	check_the_nonce( $_POST['nonce'],'safety-net-scrub-options' );
+	check_the_nonce( $_POST['nonce'], 'safety-net-scrub-options' );
 
 	// Checks passed. Scrub the options.
 	scrub_options();
 
 	// Send the AJAX response.
 	echo json_encode(
-		[
+		array(
 			'success' => true,
 			'message' => esc_html__( 'Options have been scrubbed.' ),
-		]
+		)
 	);
 
 	die();
@@ -261,27 +264,27 @@ function handle_ajax_deactivate_plugins() {
 	if ( is_production() ) {
 		// Send an AJAX warning.
 		echo json_encode(
-			[
+			array(
 				'warning' => true,
 				'message' => esc_html__( 'You can not run these tools on a production site. Please set the environment type correctly.' ),
-			]
+			)
 		);
 		die();
 	}
 
 	// Permissions and security checks.
 	check_the_permissions();
-	check_the_nonce( $_POST['nonce'],'safety-net-deactivate-plugins' );
+	check_the_nonce( $_POST['nonce'], 'safety-net-deactivate-plugins' );
 
 	// Checks passed. Scrub the options.
 	deactivate_plugins();
 
 	// Send the AJAX response.
 	echo json_encode(
-		[
+		array(
 			'success' => true,
 			'message' => esc_html__( 'Plugins have been deactivated.' ),
-		]
+		)
 	);
 
 	die();
@@ -298,10 +301,10 @@ function handle_ajax_delete_users() {
 	if ( is_production() ) {
 		// Send an AJAX warning.
 		echo json_encode(
-			[
+			array(
 				'warning' => true,
 				'message' => esc_html__( 'You can not run these tools on a production site. Please set the environment type correctly.' ),
-			]
+			)
 		);
 		die();
 	}
@@ -314,10 +317,10 @@ function handle_ajax_delete_users() {
 	delete_users_and_orders();
 
 	echo json_encode(
-		[
+		array(
 			'success' => true,
 			'message' => esc_html__( 'Users, orders, and subscriptions have been successfully deleted!' ),
-		]
+		)
 	);
 
 	die();
@@ -331,10 +334,10 @@ function handle_ajax_delete_users() {
 function check_the_permissions() {
 	if ( ! current_user_can( 'manage_options' ) ) {
 		echo json_encode(
-			[
+			array(
 				'success' => false,
 				'message' => esc_html__( 'You do not have permission to do that.' ),
-			]
+			)
 		);
 
 		die();
@@ -352,10 +355,10 @@ function check_the_permissions() {
 function check_the_nonce( string $nonce, $action ) {
 	if ( ! wp_verify_nonce( $nonce, $action ) ) {
 		echo json_encode(
-			[
+			array(
 				'success' => false,
 				'message' => esc_html__( 'Security check failed. Refresh the page and try again.' ),
-			]
+			)
 		);
 
 		die();
@@ -383,9 +386,14 @@ function add_action_links( $actions ) {
 function pause_renewal_actions() {
 	if ( 'on' === get_option( 'safety_net_pause_renewal_actions_toggle' ) ) {
 		require_once __DIR__ . '/classes/class-actionscheduler-custom-dbstore.php';
-		add_filter( 'action_scheduler_store_class', function( $class ) {
-			return 'SafetyNet\ActionScheduler_Custom_DBStore';
-		}, 101, 1 );
+		add_filter(
+			'action_scheduler_store_class',
+			function( $class ) {
+				return 'SafetyNet\ActionScheduler_Custom_DBStore';
+			},
+			101,
+			1
+		);
 	}
 }
 

--- a/includes/classes/background-anonymize-user.php
+++ b/includes/classes/background-anonymize-user.php
@@ -8,6 +8,7 @@
 namespace SafetyNet;
 
 use function SafetyNet\Anonymize\anonymize_users;
+use function SafetyNet\Anonymize\store_anonymized_user_data;
 
 /**
  * Background Anonymize User class
@@ -51,10 +52,8 @@ class Background_Anonymize_User extends \WP_Background_Process {
 		// Have to call complete function in the parent's class.
 		parent::complete();
 
-		$wpdb->query( "INSERT INTO $wpdb->users (SELECT * FROM {$wpdb->users}_temp WHERE id NOT IN (SELECT ID FROM $wpdb->users))" );
-		$wpdb->query( "DROP TABLE {$wpdb->users}_temp" );
-		$wpdb->query( "INSERT INTO $wpdb->usermeta (SELECT * FROM {$wpdb->usermeta}_temp WHERE user_id NOT IN (SELECT user_id FROM $wpdb->usermeta))" );
-		$wpdb->query( "DROP TABLE {$wpdb->usermeta}_temp" );
+		// Store the anonymized users to the default tables.
+		store_anonymized_user_data();
 
 		// Flush the cache.
 		wp_cache_flush();

--- a/includes/cli/anonymize.php
+++ b/includes/cli/anonymize.php
@@ -1,6 +1,8 @@
 <?php
 
 use function SafetyNet\Anonymize\anonymize_orders;
+use function SafetyNet\Anonymize\copy_and_clear_user_tables;
+use function SafetyNet\Anonymize\store_anonymized_user_data;
 use function SafetyNet\Anonymize\anonymize_users;
 use function SafetyNet\Anonymize\anonymize_customers;
 use function SafetyNet\Delete\delete_users_and_orders;
@@ -19,7 +21,12 @@ class SafetyNet_CLI extends WP_CLI_Command {
 	*
 	*/
 	public function anonymize( $args ) {
+
+		copy_and_clear_user_tables();
+
 		anonymize_users();
+
+		store_anonymized_user_data();
 
 		anonymize_orders();
 

--- a/includes/cli/anonymize.php
+++ b/includes/cli/anonymize.php
@@ -22,14 +22,26 @@ class SafetyNet_CLI extends WP_CLI_Command {
 	*/
 	public function anonymize( $args ) {
 
+		$info = WP_CLI::colorize( '%pThis process will anonymize your current users, orders and customers with dummy data.%n ' );
+		WP_CLI::log( $info );
+
+		WP_CLI::warning( 'Please proceed with caution if you have a site with a large number of users/orders/customers' );
+
+		WP_CLI::confirm( 'Are you sure you want to do this?' );
+
+		WP_CLI::log( '- Copying users to temporary tables ...' );
 		copy_and_clear_user_tables();
 
+		WP_CLI::log( '- Anonymizing users ... ' );
 		anonymize_users();
 
+		WP_CLI::log( '- Storing the anonymized users to the default tables ... ' );
 		store_anonymized_user_data();
 
+		WP_CLI::log( '- Anonymizing orders ... ' );
 		anonymize_orders();
 
+		WP_CLI::log( '- Anonymizing customers ... ' );
 		anonymize_customers();
 
 		update_option( 'anonymized_status', true, false );


### PR DESCRIPTION
### Description of the issue

In #55 we decided to remove the anonymization functionality from the plugin, leaving only the CLI command to anonymize the users, orders, and customers.

When I tried the `wp safety-net anonymize` CLI command it got stuck and didn't anonymize any user data. 

After taking a look at it, I've found that the problem was that the temporary tables weren't being used for copying, processing and storing the user details. These DB operations were only used for the background processes (which the CLI isn't using). 

### Changes proposed in this PR

* Move these DB operations to new standalone functions
* Call these functions when needed from the CLI command (before and after anonymizing the users)
* Since the anonymization process affects the database and can cause some issues on big sites, I've added a warning and a prompt asking for the customer to confirm the execution of this functionality.
* Added some feedback lines in the terminal to show the process of the command (it could help in case it gets stuck again due to any issues). 

![image](https://user-images.githubusercontent.com/1201868/214607806-06d0c42d-f379-46f6-8f14-46d0e4314716.png)

### Steps to test
1. Use the trunk version of the plugin
2. Create some dummy users (i.e `wp user generate 100`)
3. Run the `wp safety-net anonymize` command 
[It should get stuck without anonymizing any user]
4. Confirm that the users haven't been anonymized
5. Switch to this branch
6.  Run the `wp safety-net anonymize` command again
7. Confirm that a warning appears and you're asked for a confirmation in order to continue with the anonymization.
8. Confirm that the anonymization process gets cancelled when choosing `n`.
9. Confirm that the anonymization process starts when choosing `y`.
10. Confirm that feedback lines appear before anonymizing users, orders and customers (check the previous image)
11. Confirm that the users/orders/customers data has been properly anonymized. 

### Notes
* I've removed an orphan `wp_ajax_safety_net_anonymize_users` hook (not needed since this functionality was removed from the admin in https://github.com/a8cteam51/safety-net/pull/62. 
* I've updated the code of `includes/amin.php` to fix some phpcs issues (mostly related to shorthand syntax)
* The wording of the warning or feedback lines that appear when running the CLI command can probably be improved. Feel free to review them and suggest any changes.


Fixes #55
 