### PR TITLE
Change filter to `pre_wp_mail`

### DIFF
--- a/includes/admin.php
+++ b/includes/admin.php
@@ -28,7 +28,7 @@ function add_admin_hooks(){
 	}
 	add_action( 'action_scheduler_pre_init', __NAMESPACE__ . '\pause_renewal_actions' );
 	add_action( 'admin_notices', __NAMESPACE__ . '\show_warning' );
-	add_filter( 'wp_mail', __NAMESPACE__ . '\stop_emails', 10, 1 );
+	add_filter( 'pre_wp_mail', __NAMESPACE__ . '\stop_emails', 10, 2 );
 }
 
 /**


### PR DESCRIPTION
Safety Net was throwing a fatal:

```
[02-Mar-2023 19:01:47 UTC] PHP Fatal error:  Uncaught ArgumentCountError: Too few arguments to function SafetyNet\Admin\stop_emails(), 1 passed in /wp/wp-includes/class-wp-hook.php on line 308 and exactly 2 expected in /plugins/safety-net/includes/admin.php:416
```

We changed from using `wp_mail` to `pre_wp_mail` on #71 but looks like it was moved back to `wp_mail` on #68.

The filter then became `add_filter( 'wp_mail', __NAMESPACE__ . '\stop_emails', 10, 1 );` but the `stop_emails` function expects two parameters.

### Testing instructions

You can try to send an email when Safety Net is active:

```php
add_action( 'init', function() {
    wp_mail( 'test@example.com', 'subject', 'message' );
} );
```

Before applying this patch, a fatal will be shown. Checking `debug.log` where Safety Net should log it's email blocked message will not be present as well.

After applying this patch, the email should be properly blocked and the log entry `Email blocked: subject` will be present on the file.