### PR TITLE
Remove force Jetpack offline mode

### DIFF
--- a/includes/admin.php
+++ b/includes/admin.php
@@ -29,7 +29,6 @@ function add_admin_hooks(){
 	add_action( 'action_scheduler_pre_init', __NAMESPACE__ . '\pause_renewal_actions' );
 	add_action( 'admin_notices', __NAMESPACE__ . '\show_warning' );
 	add_filter( 'pre_wp_mail', __NAMESPACE__ . '\stop_emails', 10, 2 );
-	add_filter( 'jetpack_offline_mode', '__return_true' );
 }
 
 /**


### PR DESCRIPTION
From slack discussion, we actually don't want to force Jetpack offline mode for all dev sites. Scrubbing the options should be enough.