### PR TITLE
Add WP Remote User Sync plugin and options

### DIFF
--- a/assets/data/option_scrublist.txt
+++ b/assets/data/option_scrublist.txt
@@ -29,3 +29,4 @@ zmail_auth_code
 zmail_integ_client_secret
 zmail_refresh_token
 zmail_access_token
+wprus

--- a/assets/data/option_scrublist.txt
+++ b/assets/data/option_scrublist.txt
@@ -24,9 +24,9 @@ woocommerce_stripe_settings
 woocommerce_woocommerce_payments_settings
 woocommerce-ppcp-settings
 wpmandrill
+wprus
 yotpo_settings
 zmail_auth_code
 zmail_integ_client_secret
 zmail_refresh_token
 zmail_access_token
-wprus

--- a/assets/data/plugin_denylist.txt
+++ b/assets/data/plugin_denylist.txt
@@ -32,3 +32,4 @@ wpmandrill
 yotpo
 zapier
 zoho-mail
+wp-remote-users-sync

--- a/assets/data/plugin_denylist.txt
+++ b/assets/data/plugin_denylist.txt
@@ -28,8 +28,9 @@ webgility
 console
 mail-bank
 wp-ses
+wp-remote-users-sync
 wpmandrill
 yotpo
 zapier
 zoho-mail
-wp-remote-users-sync
+

--- a/includes/deactivate-plugins.php
+++ b/includes/deactivate-plugins.php
@@ -106,6 +106,25 @@ function scrub_options() {
 				);
 
 				update_option( $option, $modules_array );
+			} elseif ( 'wprus' === $option ) {
+				// Clear some WP Remote Users Sync options to disable only keys needed for remote connections and keep the remaining settings intact.
+				$keys_to_scrub = array( 
+					'encryption' => array (
+						'aes_key', 
+						'hmac_key'
+					) 
+				);
+				$option_array  = $option_value;
+				foreach ( $keys_to_scrub as $index => $keys ) {
+					if ( array_key_exists( $index, $option_array ) ) {
+						foreach ( $keys as $key ) {
+							if ( array_key_exists( $key, $option_array[$index] ) ) {
+								$option_array[ $index ][ $key ] = '';
+							}
+						}
+					}
+				}
+				update_option( $option, $option_array );
 			} else {
 				update_option( $option, '' );
 			}

--- a/includes/deactivate-plugins.php
+++ b/includes/deactivate-plugins.php
@@ -11,13 +11,13 @@ add_action( 'safety_net_scrub_options', __NAMESPACE__ . '\scrub_options' );
 * Deactivate plugins from a denylist
 */
 function deactivate_plugins() {
-	
-	if ( true != get_option( 'safety_net_options_scrubbed' ) ) {
-		echo json_encode(
-			[
+
+	if ( true !== get_option( 'safety_net_options_scrubbed' ) ) {
+		echo wp_json_encode(
+			array(
 				'success' => false,
 				'message' => esc_html__( 'Safety Net Error: options need to be scrubbed first.' ),
-			]
+			)
 		);
 
 		die();
@@ -108,17 +108,17 @@ function scrub_options() {
 				update_option( $option, $modules_array );
 			} elseif ( 'wprus' === $option ) {
 				// Clear some WP Remote Users Sync options to disable only keys needed for remote connections and keep the remaining settings intact.
-				$keys_to_scrub = array( 
-					'encryption' => array (
-						'aes_key', 
-						'hmac_key'
-					) 
+				$keys_to_scrub = array(
+					'encryption' => array(
+						'aes_key',
+						'hmac_key',
+					),
 				);
 				$option_array  = $option_value;
 				foreach ( $keys_to_scrub as $index => $keys ) {
 					if ( array_key_exists( $index, $option_array ) ) {
 						foreach ( $keys as $key ) {
-							if ( array_key_exists( $key, $option_array[$index] ) ) {
+							if ( array_key_exists( $key, $option_array[ $index ] ) ) {
 								$option_array[ $index ][ $key ] = '';
 							}
 						}

--- a/safety-net.php
+++ b/safety-net.php
@@ -2,7 +2,7 @@
 /*
  * Plugin Name: Safety Net
  * Description: For Team51 Development Sites. Deletes user data and more!
- * Version: 1.4.6
+ * Version: 1.4.7
  * Author: WordPress.com Special Projects
  * Author URI: https://wpspecialprojects.wordpress.com
  * Text Domain: safety-net


### PR DESCRIPTION
Added the [WP Remote User Sync](https://wordpress.org/plugins/wp-remote-users-sync/) to deny list and the plugin options to scrub list.

Hey @NickGreen! It looks like the plugin stores all options in a `wprus` array, is there a way to only scrub the encryption keys? 