### PR TITLE
Misc fixes

### DIFF
--- a/includes/deactivate-plugins.php
+++ b/includes/deactivate-plugins.php
@@ -126,7 +126,13 @@ function scrub_options() {
 				}
 				update_option( $option, $option_array );
 			} else {
-				update_option( $option, '' );
+				// Some plugins don't like it when options are deleted, so we will save their value as either an empty string or array, depending on which it already is.
+				if ( is_array( get_option( $option ) ) ) {
+					$empty_array = array();
+					update_option( $option, $empty_array );
+				} else {
+					update_option( $option, '' );
+				}
 			}
 		}
 	}

--- a/includes/deactivate-plugins.php
+++ b/includes/deactivate-plugins.php
@@ -12,7 +12,7 @@ add_action( 'safety_net_scrub_options', __NAMESPACE__ . '\scrub_options' );
 */
 function deactivate_plugins() {
 
-	if ( true !== get_option( 'safety_net_options_scrubbed' ) ) {
+	if ( '1' !== get_option( 'safety_net_options_scrubbed' ) ) {
 		echo wp_json_encode(
 			array(
 				'success' => false,

--- a/includes/delete.php
+++ b/includes/delete.php
@@ -15,7 +15,7 @@ add_action( 'safety_net_delete_data', __NAMESPACE__ . '\delete_users_and_orders'
  */
 function delete_users_and_orders() {
 
-	if ( true != get_option( 'safety_net_plugins_deactivated' ) ) {
+	if ( '1' !== get_option( 'safety_net_plugins_deactivated' ) ) {
 		echo json_encode(
 			[
 				'success' => false,

--- a/safety-net.php
+++ b/safety-net.php
@@ -2,7 +2,7 @@
 /*
  * Plugin Name: Safety Net
  * Description: For Team51 Development Sites. Deletes user data and more!
- * Version: 1.4.9
+ * Version: 1.4.10
  * Author: WordPress.com Special Projects
  * Author URI: https://wpspecialprojects.wordpress.com
  * Text Domain: safety-net


### PR DESCRIPTION
## Changes in this PR

- When overwriting options with blank values, allow for empty arrays to be saved to prevent errors
- Fix eval that had been changed for PHPCS, but was checking for `true` instead of '1'