### PR TITLE
Add WooCommerce Zapier to plugin denylist

### DIFF
--- a/assets/data/option_scrublist.txt
+++ b/assets/data/option_scrublist.txt
@@ -11,6 +11,7 @@ mailster_options
 mc4wp
 novos_klaviyo_option_name
 shareasale_wc_tracker_options
+woocommerce-ppcp-settings
 woocommerce_afterpay_settings
 woocommerce_braintree_credit_card_settings
 woocommerce_braintree_paypal_settings
@@ -22,11 +23,10 @@ woocommerce_stripe_account_settings
 woocommerce_stripe_api_settings
 woocommerce_stripe_settings
 woocommerce_woocommerce_payments_settings
-woocommerce-ppcp-settings
 wpmandrill
 wprus
 yotpo_settings
+zmail_access_token
 zmail_auth_code
 zmail_integ_client_secret
 zmail_refresh_token
-zmail_access_token

--- a/assets/data/plugin_denylist.txt
+++ b/assets/data/plugin_denylist.txt
@@ -3,10 +3,12 @@ afterpay
 algolia
 automator
 avatax
+console
 hubspot
 in-stock-mailer-for-wc
 klaviyo
 leadin
+mail-bank
 mailchimp
 mailgun
 mailpoet
@@ -25,12 +27,10 @@ socketlabs
 sparkpost
 stripe
 webgility
-console
-mail-bank
-wp-ses
+woocommerce-zapier
 wp-remote-users-sync
+wp-ses
 wpmandrill
 yotpo
 zapier
 zoho-mail
-woocommerce-zapier

--- a/assets/data/plugin_denylist.txt
+++ b/assets/data/plugin_denylist.txt
@@ -33,4 +33,4 @@ wpmandrill
 yotpo
 zapier
 zoho-mail
-
+woocommerce-zapier

--- a/safety-net.php
+++ b/safety-net.php
@@ -2,7 +2,7 @@
 /*
  * Plugin Name: Safety Net
  * Description: For Team51 Development Sites. Deletes user data and more!
- * Version: 1.4.12
+ * Version: 1.4.13
  * Author: WordPress.com Special Projects
  * Author URI: https://wpspecialprojects.wordpress.com
  * Text Domain: safety-net


### PR DESCRIPTION
This should be enough to fix #102, as per the [docs](https://woocommerce.com/document/woocommerce-zapier-integration/#section-98). Existing Zaps will be kept intact.

If, instead, we need to remove any saved information we can use something like this:

```php
    $wpdb->query( "DROP TABLE IF EXISTS `{$wpdb->prefix}wc_zapier_history`" );

    // Delete all existing WooCommerce Zapier Webhooks.
    $wpdb->query( "DELETE FROM `{$wpdb->prefix}wc_webhooks` WHERE `name` = 'WooCommerce Zapier' AND `delivery_url` LIKE '%hooks.zapier.com%'" );

    // Delete all existing WooCommerce Zapier REST API Keys.
    $wpdb->query( "DELETE FROM `{$wpdb->prefix}woocommerce_api_keys` WHERE `description` LIKE '%Zapier%'" );

    // Delete all existing 1.9.x Legacy Zapier Feed records.
    foreach ( get_posts(
        array(
            'post_type'      => 'wc_zapier_feed',
            'posts_per_page' => -1,
        )
    ) as $feed ) {
        if ( isset( $feed->ID ) ) {
            wp_delete_post( $feed->ID, false );
        }
    }
    $wpdb->query( "DELETE FROM `$wpdb->options` WHERE option_name LIKE 'wc\_zapier\_%';" );
```