### PR TITLE
Disable Enhanced Distribution from Jetpack modules

### DIFF
--- a/includes/deactivate-plugins.php
+++ b/includes/deactivate-plugins.php
@@ -96,7 +96,7 @@ function scrub_options() {
 				update_option( $option, $option_array );
 			} elseif ( 'jetpack_active_modules' === $option ) {
 				// Clear some Jetpack options to disable specific modules.
-				$modules_to_disable = array( 'publicize', 'subscriptions' );
+				$modules_to_disable = array( 'enhanced-distribution', 'publicize', 'subscriptions' );
 				$modules_array      = array_filter(
 					$option_value,
 					function( $v ) use ( $modules_to_disable ) {


### PR DESCRIPTION
## Issue

When active on private/staging sites, Jetpack's [Enhanced Distribution](https://jetpack.com/support/jetpack-social/enhanced-distribution/) module can cause content to appear in the [WordPress.com Firehose](https://developer.wordpress.com/docs/firehose/), which is undesirable.

## Suggested fix

Similar to https://github.com/a8cteam51/safety-net/pull/49, this PR disables Enhanced Distribution.