### PR TITLE
Scrubs subscribers for the Newsletter plugin

### DIFF
--- a/includes/delete.php
+++ b/includes/delete.php
@@ -72,6 +72,14 @@ function delete_users_and_orders() {
 		$wpdb->query( "DELETE FROM {$wpdb->prefix}wpml_mails" );
 	}
 
+    // Delete Newsletter plugin subscribers
+    $table_name = $wpdb->prefix . 'newsletter';
+    if ( $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $table_name ) ) === $table_name ) {
+        $wpdb->query( "DELETE FROM {$wpdb->prefix}newsletter" );
+    }
+
+
+
 	// Reassigning all posts to the first admin user
 	reassign_all_posts();
 


### PR DESCRIPTION
The [Newsletter plugin](https://wordpress.org/plugins/newsletter/) (currently in use on keysjazzbistro.com at least, possibly others) stores subscriber emails in the `wp_newsletter` table. This update clears those subscribers from the table.