### PR TITLE
Limit JP subs to non-existing category

### DIFF
--- a/includes/common.php
+++ b/includes/common.php
@@ -5,8 +5,13 @@ namespace SafetyNet\Common;
 add_filter( 'send_password_change_email', '__return_false' );
 add_filter( 'send_email_change_email', '__return_false' );
 
-// stop Jetpack post subscription email sending per https://developer.jetpack.com/hooks/jetpack_is_post_mailable/
-add_filter( 'jetpack_is_post_mailable', '__return_false' );
+// Jetpack Subscriptions will only be sent for posts in the "non-existing" category, effectively stopping them
+add_filter(
+	'jetpack_subscriptions_exclude_all_categories_except',
+	function () {
+		return array( 'non-existing' );	
+	}
+);
 
 // Discourage search engines from indexing the site and disallow the entire site in robots.txt.
 add_filter( 'option_blog_public', '__return_zero' );


### PR DESCRIPTION
## Changes in this PR

- Removed deprecated JP function: `jetpack_is_post_mailable`
- Instead use `jetpack_subscriptions_exclude_all_categories_except` to stop all subs