### PR TITLE
Remove some options from scrubbing that are needed on WordPress.com

### DIFF
--- a/includes/scrub-options.php
+++ b/includes/scrub-options.php
@@ -102,7 +102,7 @@ function scrub_options() {
  */
 function safety_net_scrub_options_wpcom( $options_to_clear ) {
 	if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
-		$unset_wpcom_options = array( 'jetpack_private_options', 'jetpack_secrets' );
+		$unset_wpcom_options = array( 'jetpack_private_options', 'jetpack_secrets', 'jetpack_active_modules' );
 		$options_to_clear = array_diff( $options_to_clear, $unset_wpcom_options );
 	}
 

--- a/includes/scrub-options.php
+++ b/includes/scrub-options.php
@@ -98,19 +98,14 @@ function scrub_options() {
  *
  * @param array $options_to_clear Options to clear.
  *
- * @return void
+ * @return array
  */
 function safety_net_scrub_options_wpcom( $options_to_clear ) {
 	if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
 		$unset_wpcom_options = array( 'jetpack_private_options', 'jetpack_secrets' );
-
-		foreach ( $unset_wpcom_options as $option ) {
-			$option_key = array_search( $option, $options_to_clear );
-
-			if ( false !== $option_key ) {
-				unset( $options_to_clear[ $option_key ] );
-			}
-		}
+		$options_to_clear = array_diff( $options_to_clear, $unset_wpcom_options );
 	}
+
+	return $options_to_clear;
 }
 add_filter( 'safety_net_options_to_clear', __NAMESPACE__ . '\safety_net_scrub_options_wpcom' );

--- a/includes/scrub-options.php
+++ b/includes/scrub-options.php
@@ -92,3 +92,25 @@ function scrub_options() {
 
 	update_option( 'safety_net_options_scrubbed', true );
 }
+
+/**
+ * Remove some options from scrubbing that are needed on WordPress.com.
+ *
+ * @param array $options_to_clear Options to clear.
+ *
+ * @return void
+ */
+function safety_net_scrub_options_wpcom( $options_to_clear ) {
+	if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
+		$unset_wpcom_options = array( 'jetpack_private_options', 'jetpack_secrets' );
+
+		foreach ( $unset_wpcom_options as $option ) {
+			$option_key = array_search( $option, $options_to_clear );
+
+			if ( false !== $option_key ) {
+				unset( $options_to_clear[ $option_key ] );
+			}
+		}
+	}
+}
+add_filter( 'safety_net_options_to_clear', 'safety_net_scrub_options_wpcom' );

--- a/includes/scrub-options.php
+++ b/includes/scrub-options.php
@@ -113,4 +113,4 @@ function safety_net_scrub_options_wpcom( $options_to_clear ) {
 		}
 	}
 }
-add_filter( 'safety_net_options_to_clear', 'safety_net_scrub_options_wpcom' );
+add_filter( 'safety_net_options_to_clear', __NAMESPACE__ . '\safety_net_scrub_options_wpcom' );


### PR DESCRIPTION
### Changes proposed in this PR

- Remove Jetpack options from scrubbing that are needed for an active Jetpack connection on WordPress.com, because staging sites don't work on WP.com without Jetpack