### PR TITLE
Disable AutomateWoo workflows and scrub the queue

### DIFF
--- a/includes/scrub-options.php
+++ b/includes/scrub-options.php
@@ -91,10 +91,11 @@ function scrub_options() {
 		}
 	}
 
-	// Disable AutomateWoo workflows and clear the queue
+	// Disable AutomateWoo workflows, clear the queue, and set scheduled actions to "done"
 	$wpdb->query( "UPDATE $wpdb->posts SET post_status = 'aw-disabled' WHERE post_type = 'aw_workflow' AND post_status = 'publish'" );
 	$wpdb->query( "DELETE FROM {$wpdb->prefix}automatewoo_queue" );
 	$wpdb->query( "DELETE FROM {$wpdb->prefix}automatewoo_queue_meta" );
+	$wpdb->query( "UPDATE {$wpdb->prefix}actionscheduler_actions SET status = 'done' WHERE status = 'pending' AND hook LIKE '%automatewoo%'" );
 
 	update_option( 'safety_net_options_scrubbed', true );
 

--- a/includes/scrub-options.php
+++ b/includes/scrub-options.php
@@ -12,6 +12,7 @@ add_action( 'safety_net_scrub_options', __NAMESPACE__ . '\scrub_options' );
 * Clear options such as API keys so that plugins won't talk to 3rd parties
 */
 function scrub_options() {
+	global $wpdb;
 
 	safety_net_update_option_direct( 'admin_email', 'safetynet@scrubbedthis.option' );
 
@@ -89,6 +90,11 @@ function scrub_options() {
 			}
 		}
 	}
+
+	// Disable AutomateWoo workflows and clear the queue
+	$wpdb->query( "UPDATE $wpdb->posts SET post_status = 'aw-disabled' WHERE post_type = 'aw_workflow' AND post_status = 'publish'" );
+	$wpdb->query( "DELETE FROM {$wpdb->prefix}automatewoo_queue" );
+	$wpdb->query( "DELETE FROM {$wpdb->prefix}automatewoo_queue_meta" );
 
 	update_option( 'safety_net_options_scrubbed', true );
 


### PR DESCRIPTION
This PR addresses the need to handle the AutomateWoo plugin.

1. Disables all active AutomateWoo workflows.
2. Scrubs the AutomateWoo queue.

Mentions #124 