### PR TITLE
Remove prefix from table names

### DIFF
--- a/includes/delete.php
+++ b/includes/delete.php
@@ -69,8 +69,8 @@ function delete_users_and_orders() {
 	// Delete Woo payment tokens
 	$table_name = $wpdb->prefix . 'woocommerce_payment_tokens';
 	if ( $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $table_name ) ) === $table_name ) {
-		$wpdb->query( "DELETE FROM {$wpdb->prefix}wp_woocommerce_payment_tokens" );
-		$wpdb->query( "DELETE FROM {$wpdb->prefix}wp_woocommerce_payment_tokenmeta" );
+		$wpdb->query( "DELETE FROM {$wpdb->prefix}woocommerce_payment_tokens" );
+		$wpdb->query( "DELETE FROM {$wpdb->prefix}woocommerce_payment_tokenmeta" );
 	}
 
 	// Delete Woo customers and analytics

--- a/safety-net.php
+++ b/safety-net.php
@@ -2,7 +2,7 @@
 /*
  * Plugin Name: Safety Net
  * Description: For Team51 Development Sites. Deletes user data and more!
- * Version: 1.4.18
+ * Version: 1.4.19
  * Author: WordPress.com Special Projects
  * Author URI: https://wpspecialprojects.wordpress.com
  * Text Domain: safety-net


### PR DESCRIPTION
Removes the `wp_` prefix from the table names. These are already included with `{$wpdb->prefix}`

Fixes #129 