### PR TITLE
Fix wpcom check

### DIFF
--- a/includes/scrub-options.php
+++ b/includes/scrub-options.php
@@ -20,14 +20,15 @@ function scrub_options() {
 	$options_to_clear = get_denylist_array( 'options' );
 	$options_to_clear = apply_filters( 'safety_net_options_to_clear', $options_to_clear );
 
-	// Check if it’s an Atomic site either via the jetpack function or URL.
+	// Check if it’s an Atomic site either via the Jetpack function or URL.
 	$is_atomic_site = false;
 	if ( function_exists( 'jetpack_is_atomic_site' ) && jetpack_is_atomic_site() ) {
 		$is_atomic_site = true;
 	} elseif ( str_ends_with( home_url(), 'wpcomstaging.com' ) ) {
 		$is_atomic_site = true;
 	}
-	
+
+	// Leave these options intact on Atomic, so that we don't disconnect Jetpack
 	if ( $is_atomic_site ) {
 		$unset_wpcom_options = array( 'jetpack_private_options', 'jetpack_secrets' );
 		$options_to_clear    = array_diff( $options_to_clear, $unset_wpcom_options );
@@ -124,34 +125,6 @@ function scrub_options() {
 	// Clear object cache since the updates happen directly in the database.
 	wp_cache_flush();
 }
-
-/**
- * Remove some options from scrubbing that are needed on WordPress.com.
- *
- * @param array $options_to_clear Options to clear.
- *
- * @return array
- */
-function safety_net_scrub_options_wpcom( $options_to_clear ) {
-
-	$url = home_url( $_SERVER['REQUEST_URI'] );
-
-	// Check if it’s an Atomic site either via the function or URL.
-	$is_atomic_site = false;
-	if ( function_exists( 'jetpack_is_atomic_site' ) && jetpack_is_atomic_site() ) {
-		$is_atomic_site = true;
-	} elseif ( str_ends_with( $url, 'wpcomstaging.com' ) ) {
-		$is_atomic_site = true;
-	}
-	
-	if ( $is_atomic_site ) {
-		$unset_wpcom_options = array( 'jetpack_private_options', 'jetpack_secrets' );
-		$options_to_clear    = array_diff( $options_to_clear, $unset_wpcom_options );
-	}
-
-	return $options_to_clear;
-}
-// add_filter( 'safety_net_options_to_clear', __NAMESPACE__ . '\safety_net_scrub_options_wpcom' );
 
 /**
  * Updates options directly in the database to prevent notifications from being sent.

--- a/includes/scrub-options.php
+++ b/includes/scrub-options.php
@@ -1,6 +1,7 @@
 <?php
 
 namespace SafetyNet\ScrubOptions;
+
 use WC_Data_Store;
 use WC_Webhook;
 
@@ -119,9 +120,14 @@ function scrub_options() {
  * @return array
  */
 function safety_net_scrub_options_wpcom( $options_to_clear ) {
-	if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
-		$unset_wpcom_options = array( 'jetpack_private_options', 'jetpack_secrets', 'jetpack_active_modules' );
-		$options_to_clear = array_diff( $options_to_clear, $unset_wpcom_options );
+
+	$url                    = $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'];
+	$ends_with_wpcomstaging = substr( $url, -18 ) === '.wpcomstaging.com';
+
+	// checking 2 different ways if it's an Atomic site
+	if ( ( function_exists( 'jetpack_is_atomic_site' ) && jetpack_is_atomic_site() ) || $ends_with_wpcomstaging ) {
+		$unset_wpcom_options = array( 'jetpack_private_options', 'jetpack_secrets' );
+		$options_to_clear    = array_diff( $options_to_clear, $unset_wpcom_options );
 	}
 
 	return $options_to_clear;
@@ -130,10 +136,10 @@ add_filter( 'safety_net_options_to_clear', __NAMESPACE__ . '\safety_net_scrub_op
 
 /**
  * Updates options directly in the database to prevent notifications from being sent.
- * 
+ *
  * @param string $option_name The name of the option to update.
  * @param mixed $option_value The value to set the option to.
- * 
+ *
  * @return void
  */
 function safety_net_update_option_direct( $option_name, $option_value ) {

--- a/includes/scrub-options.php
+++ b/includes/scrub-options.php
@@ -121,12 +121,11 @@ function scrub_options() {
  */
 function safety_net_scrub_options_wpcom( $options_to_clear ) {
 
-	$url                    = $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'];
-	$ends_with_wpcomstaging = substr( $url, -18 ) === '.wpcomstaging.com';
+	$url = $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'];
 
 	// checking 2 different ways if it's an Atomic site
-	if ( ( function_exists( 'jetpack_is_atomic_site' ) && jetpack_is_atomic_site() ) || $ends_with_wpcomstaging ) {
-		$unset_wpcom_options = array( 'jetpack_private_options', 'jetpack_secrets' );
+	if ( ( function_exists( 'jetpack_is_atomic_site' ) && jetpack_is_atomic_site() ) || ( '.wpcomstaging.com' === substr( $url, -18 ) ) ) {
+		$unset_wpcom_options = array( 'jetpack_private_options', 'jetpack_secrets', 'jetpack_active_modules' );
 		$options_to_clear    = array_diff( $options_to_clear, $unset_wpcom_options );
 	}
 

--- a/includes/scrub-options.php
+++ b/includes/scrub-options.php
@@ -20,6 +20,19 @@ function scrub_options() {
 	$options_to_clear = get_denylist_array( 'options' );
 	$options_to_clear = apply_filters( 'safety_net_options_to_clear', $options_to_clear );
 
+	// Check if it’s an Atomic site either via the jetpack function or URL.
+	$is_atomic_site = false;
+	if ( function_exists( 'jetpack_is_atomic_site' ) && jetpack_is_atomic_site() ) {
+		$is_atomic_site = true;
+	} elseif ( str_ends_with( home_url(), 'wpcomstaging.com' ) ) {
+		$is_atomic_site = true;
+	}
+	
+	if ( $is_atomic_site ) {
+		$unset_wpcom_options = array( 'jetpack_private_options', 'jetpack_secrets' );
+		$options_to_clear    = array_diff( $options_to_clear, $unset_wpcom_options );
+	}
+
 	foreach ( $options_to_clear as $option ) {
 		$option_value = get_option( $option );
 		if ( $option_value ) {
@@ -121,17 +134,24 @@ function scrub_options() {
  */
 function safety_net_scrub_options_wpcom( $options_to_clear ) {
 
-	$url = $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'];
+	$url = home_url( $_SERVER['REQUEST_URI'] );
 
-	// checking 2 different ways if it's an Atomic site
-	if ( ( function_exists( 'jetpack_is_atomic_site' ) && jetpack_is_atomic_site() ) || ( '.wpcomstaging.com' === substr( $url, -18 ) ) ) {
-		$unset_wpcom_options = array( 'jetpack_private_options', 'jetpack_secrets', 'jetpack_active_modules' );
+	// Check if it’s an Atomic site either via the function or URL.
+	$is_atomic_site = false;
+	if ( function_exists( 'jetpack_is_atomic_site' ) && jetpack_is_atomic_site() ) {
+		$is_atomic_site = true;
+	} elseif ( str_ends_with( $url, 'wpcomstaging.com' ) ) {
+		$is_atomic_site = true;
+	}
+	
+	if ( $is_atomic_site ) {
+		$unset_wpcom_options = array( 'jetpack_private_options', 'jetpack_secrets' );
 		$options_to_clear    = array_diff( $options_to_clear, $unset_wpcom_options );
 	}
 
 	return $options_to_clear;
 }
-add_filter( 'safety_net_options_to_clear', __NAMESPACE__ . '\safety_net_scrub_options_wpcom' );
+// add_filter( 'safety_net_options_to_clear', __NAMESPACE__ . '\safety_net_scrub_options_wpcom' );
 
 /**
  * Updates options directly in the database to prevent notifications from being sent.


### PR DESCRIPTION
### Changes in this PR

Checking for an IS_WPCOM constant was not returning as defined, so I chose two alternate ways to check. One if Jetpack is enabled, and the other just checking for a wpcomstaging.com URL.

This will now not scrub the two main Jetpack options, and leave it connected on Atomic staging sites.

Note: I've gone ahead and deactivated some of the modules still, such as subscriptions, since we don't want those going out on staging sites.