### PR TITLE
Add delete transients

### DIFF
--- a/assets/js/safety-net-admin.js
+++ b/assets/js/safety-net-admin.js
@@ -5,6 +5,18 @@
 	const deactivatePluginsButton = document.getElementById( 'safety-net-deactivate-plugins' );
 	const deleteUsersButton = document.getElementById( 'safety-net-delete-users' );
 	const settingsTitle = document.getElementById( 'safety-net-settings-title' );
+	const deleteTransientsButton = document.getElementById( 'safety-net-delete-transients' );
+
+	function deleteTransients() {
+		if ( ! confirm( 'Are you sure you want to delete transients? This cannot be undone!') ) {
+			return;
+		}
+
+		ajax({
+			action: 'safety_net_delete_transients',
+			nonce: deleteTransientsButton.dataset.nonce,
+		});
+	}
 
 	function scrubOptions() {
 		if ( ! confirm( 'Are you sure you want to scrub options? This cannot be undone!') ) {
@@ -147,5 +159,10 @@
 	// If the delete users button exists, add a click event listener.
 	if (deleteUsersButton) {
 		deleteUsersButton.addEventListener('click', deleteUsers);
+	}
+
+	// If the delete transients button exists, add a click event listener.
+	if (deleteTransientsButton) {
+		deleteTransientsButton.addEventListener('click', deleteTransients);
 	}
 })(window, document, jQuery);

--- a/includes/admin.php
+++ b/includes/admin.php
@@ -6,6 +6,7 @@ use function SafetyNet\ScrubOptions\scrub_options;
 use function SafetyNet\DeactivatePlugins\deactivate_plugins;
 use function SafetyNet\Delete\delete_users_and_orders;
 use function SafetyNet\Utilities\is_production;
+use function SafetyNet\DeleteTransients\delete_transients;
 
 add_filter( 'init', __NAMESPACE__ . '\add_admin_hooks' );
 
@@ -24,6 +25,7 @@ function add_admin_hooks() {
 		add_action( 'wp_ajax_safety_net_scrub_options', __NAMESPACE__ . '\handle_ajax_scrub_options' );
 		add_action( 'wp_ajax_safety_net_deactivate_plugins', __NAMESPACE__ . '\handle_ajax_deactivate_plugins' );
 		add_action( 'wp_ajax_safety_net_delete_users', __NAMESPACE__ . '\handle_ajax_delete_users' );
+		add_action( 'wp_ajax_safety_net_delete_transients', __NAMESPACE__ . '\handle_ajax_delete_transients' );
 		add_filter( 'plugin_action_links_' . SAFETY_NET_BASENAME, __NAMESPACE__ . '\add_action_links' );
 	}
 	add_action( 'action_scheduler_pre_init', __NAMESPACE__ . '\pause_renewal_actions' );
@@ -122,7 +124,7 @@ function settings_init() {
 
 	add_settings_field(
 		'safety_net_delete_users',
-		esc_html__( 'Delete All Users, Orders, and Subscriptions', 'safety-net' ),
+		esc_html__( 'Delete Users, Orders, and Subscriptions', 'safety-net' ),
 		__NAMESPACE__ . '\render_field',
 		'safety_net_options',
 		'safety_net_option',
@@ -131,6 +133,20 @@ function settings_init() {
 			'id'          => 'safety-net-delete-users',
 			'button_text' => esc_html__( 'Delete', 'safety-net' ),
 			'description' => esc_html__( 'Deletes all non-admin users, as well as WooCommerce orders and subscriptions.', 'safety-net' ),
+		)
+	);
+
+	add_settings_field(
+		'safety_net_delete_transients',
+		esc_html__( 'Delete Transients', 'safety-net' ),
+		__NAMESPACE__ . '\render_field',
+		'safety_net_options',
+		'safety_net_option',
+		array(
+			'type'        => 'button',
+			'id'          => 'safety-net-delete-transients',
+			'button_text' => esc_html__( 'Delete', 'safety-net' ),
+			'description' => esc_html__( 'Deletes all transients.', 'safety-net' ),
 		)
 	);
 
@@ -328,6 +344,30 @@ function handle_ajax_delete_users() {
 		array(
 			'success' => true,
 			'message' => esc_html__( 'Users, orders, and subscriptions have been successfully deleted!' ),
+		)
+	);
+
+	die();
+}
+
+/**
+ * Handles the AJAX request for deleting transients.
+ *
+ * @return void
+ */
+function handle_ajax_delete_transients() {
+
+	// Permissions and security checks.
+	check_the_permissions();
+	check_the_nonce( $_POST['nonce'], 'safety-net-delete-transients' ); // phpcs:ignore WordPress.Security.NonceVerification
+
+	// Checks passed. Delete the transients.
+	delete_transients();
+
+	echo wp_json_encode(
+		array(
+			'success' => true,
+			'message' => esc_html__( 'Transients have been deleted.' ),
 		)
 	);
 

--- a/includes/bootstrap.php
+++ b/includes/bootstrap.php
@@ -12,7 +12,7 @@ add_action( 'safety_net_loaded', __NAMESPACE__ . '\maybe_pause_renewal_actions' 
 add_action( 'safety_net_loaded', __NAMESPACE__ . '\maybe_scrub_options' );
 add_action( 'safety_net_loaded', __NAMESPACE__ . '\maybe_deactivate_plugins' );
 add_action( 'safety_net_loaded', __NAMESPACE__ . '\maybe_delete_data' );
-
+add_action( 'safety_net_loaded', __NAMESPACE__ . '\maybe_delete_transients' );
 /**
  * Determines if we should set the 'Pause renewal actions' toggle when first loading the plugin.
  *
@@ -29,6 +29,25 @@ function maybe_pause_renewal_actions() {
 	}
 
 	update_option( 'safety_net_pause_renewal_actions_toggle', 'on' );
+}
+
+/**
+ * Determines if transients should be deleted.
+ *
+ * Transients will be deleted if we're on staging, development, or local AND they haven't already been deleted.
+ */
+function maybe_delete_transients() {
+	// If transients have already been deleted, skip.
+	if ( get_option( 'safety_net_transients_deleted' ) ) {
+		return;
+	}
+
+	// If we're not on staging, development, or a local environment, return.
+	if ( is_production() ) {
+		return;
+	}
+
+	do_action( 'safety_net_delete_transients' );
 }
 
 /**

--- a/includes/classes/cli/class-safetynet-cli.php
+++ b/includes/classes/cli/class-safetynet-cli.php
@@ -1,6 +1,7 @@
 <?php
 
 use function SafetyNet\Delete\delete_users_and_orders;
+use function SafetyNet\DeleteTransients\delete_transients;
 
 /**
 * Anonymizer command line utilities.
@@ -19,6 +20,20 @@ class SafetyNet_CLI extends WP_CLI_Command {
 		delete_users_and_orders();
 
 		WP_CLI::success( __( 'Users and their data have been deleted' ) );
+	}
+
+	/**
+	 * Delete all transients
+	 *
+	 * ## EXAMPLES
+	 *
+	 * wp safety-net delete-transients
+	 *
+	 */
+	public function delete_transients() {
+		delete_transients();
+
+		WP_CLI::success( __( 'Transients have been deleted' ) );
 	}
 
 	/**

--- a/includes/delete-transients.php
+++ b/includes/delete-transients.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace SafetyNet\DeleteTransients;
+
+add_action( 'safety_net_delete_transients', __NAMESPACE__ . '\delete_transients' );
+
+/**
+ * Deletes all transients.
+ *
+ * @return void
+ */
+function delete_transients() {
+
+	global $wpdb;
+
+	// Delete all transients
+	$wpdb->query( "DELETE FROM $wpdb->options WHERE option_name LIKE '_transient_%'" );
+
+	// Set option so this function doesn't run again.
+	update_option( 'safety_net_transients_deleted', true );
+
+	wp_cache_flush();
+}

--- a/safety-net.php
+++ b/safety-net.php
@@ -25,6 +25,7 @@ require_once __DIR__ . '/includes/admin.php';
 require_once __DIR__ . '/includes/bootstrap.php';
 require_once __DIR__ . '/includes/common.php';
 require_once __DIR__ . '/includes/delete.php';
+require_once __DIR__ . '/includes/delete-transients.php';
 require_once __DIR__ . '/includes/utilities.php';
 require_once __DIR__ . '/includes/deactivate-plugins.php';
 require_once __DIR__ . '/includes/scrub-options.php';


### PR DESCRIPTION
### Changes proposed in this PR

- Add option to delete transients
- Delete all transients on plugin activation

### Testing

1. Create some action that will add some transients in the DB
2. Install and activate Safety net
3. The transients should be deleted

--- 

1. Install and activate Safety net
2. Create some action that will add some transients in the DB
3. Go to Safety net options and use the button to delete all transients
4. The transients should be deleted

---

1. Install and activate Safety net
2. Create some action that will add some transients in the DB
3. Use the CLI command `wp safety-net delete-transients`
4. The transients should be deleted

Mentions #137 