### PR TITLE
Add routeapp to plugin denylist

### DIFF
--- a/assets/data/plugin_denylist.txt
+++ b/assets/data/plugin_denylist.txt
@@ -22,6 +22,7 @@ postmark
 postmatic
 publish-to-apple-news
 referralcandy
+routeapp
 sendgrid
 sendinblue
 shareasale


### PR DESCRIPTION
Adds the [Route App plugin](https://wordpress.org/plugins/routeapp/) to the plugin denylist.

Part of a permanent fix for https://github.com/a8cteam51/team51-dev-requests/issues/5365