### PR TITLE
Disable WooCommerce Webhooks

### DIFF
--- a/assets/js/safety-net-admin.js
+++ b/assets/js/safety-net-admin.js
@@ -6,6 +6,7 @@
 	const deleteUsersButton = document.getElementById( 'safety-net-delete-users' );
 	const settingsTitle = document.getElementById( 'safety-net-settings-title' );
 	const deleteTransientsButton = document.getElementById( 'safety-net-delete-transients' );
+	const disableWebhooksButton = document.getElementById( 'safety-net-disable-webhooks' );
 
 	function deleteTransients() {
 		if ( ! confirm( 'Are you sure you want to delete transients? This cannot be undone!') ) {
@@ -49,6 +50,17 @@
 		ajax({
 			action: 'safety_net_delete_users',
 			nonce: deleteUsersButton.dataset.nonce,
+		});
+	}
+
+	function disableWebhooks() {
+		if ( ! confirm( 'Are you sure you want to disable webhooks? This cannot be undone!') ) {
+			return;
+		}
+
+		ajax({
+			action: 'safety_net_disable_webhooks',
+			nonce: disableWebhooksButton.dataset.nonce,
 		});
 	}
 
@@ -164,5 +176,10 @@
 	// If the delete transients button exists, add a click event listener.
 	if (deleteTransientsButton) {
 		deleteTransientsButton.addEventListener('click', deleteTransients);
+	}
+
+	// If the disable webhooks button exists, add a click event listener.
+	if (disableWebhooksButton) {
+		disableWebhooksButton.addEventListener('click', disableWebhooks);
 	}
 })(window, document, jQuery);

--- a/includes/admin.php
+++ b/includes/admin.php
@@ -409,6 +409,8 @@ function handle_ajax_disable_webhooks() {
 			'message' => esc_html__( 'Webhooks have been disabled.' ),
 		)
 	);
+
+	die();
 }
 
 /**

--- a/includes/admin.php
+++ b/includes/admin.php
@@ -7,7 +7,7 @@ use function SafetyNet\DeactivatePlugins\deactivate_plugins;
 use function SafetyNet\Delete\delete_users_and_orders;
 use function SafetyNet\Utilities\is_production;
 use function SafetyNet\DeleteTransients\delete_transients;
-
+use function SafetyNet\DisableWebhooks\disable_webhooks;
 add_filter( 'init', __NAMESPACE__ . '\add_admin_hooks' );
 
 /**
@@ -26,6 +26,7 @@ function add_admin_hooks() {
 		add_action( 'wp_ajax_safety_net_deactivate_plugins', __NAMESPACE__ . '\handle_ajax_deactivate_plugins' );
 		add_action( 'wp_ajax_safety_net_delete_users', __NAMESPACE__ . '\handle_ajax_delete_users' );
 		add_action( 'wp_ajax_safety_net_delete_transients', __NAMESPACE__ . '\handle_ajax_delete_transients' );
+		add_action( 'wp_ajax_safety_net_disable_webhooks', __NAMESPACE__ . '\handle_ajax_disable_webhooks' );
 		add_filter( 'plugin_action_links_' . SAFETY_NET_BASENAME, __NAMESPACE__ . '\add_action_links' );
 	}
 	add_action( 'action_scheduler_pre_init', __NAMESPACE__ . '\pause_renewal_actions' );
@@ -119,6 +120,20 @@ function settings_init() {
 			'id'          => 'safety-net-deactivate-plugins',
 			'button_text' => esc_html__( 'Deactivate Plugins', 'safety-net' ),
 			'description' => esc_html__( 'Deactivates a handful of denylisted plugins. Also, runs through installed Woo payment gateways and deactivates them (deactivates the actual plugin, not from the checkout settings).', 'safety-net' ),
+		)
+	);
+
+	add_settings_field(
+		'safety_net_disable_webhooks',
+		esc_html__( 'Disable Webhooks', 'safety-net' ),
+		__NAMESPACE__ . '\render_field',
+		'safety_net_options',
+		'safety_net_option',
+		array(
+			'type'        => 'button',
+			'id'          => 'safety-net-disable-webhooks',
+			'button_text' => esc_html__( 'Disable Webhooks', 'safety-net' ),
+			'description' => esc_html__( 'Disables all WooCommerce webhooks.', 'safety-net' ),
 		)
 	);
 
@@ -372,6 +387,28 @@ function handle_ajax_delete_transients() {
 	);
 
 	die();
+	}
+
+/**
+ * Handles the AJAX request for disabling webhooks.
+ *
+ * @return void
+ */
+function handle_ajax_disable_webhooks() {
+
+	// Permissions and security checks.
+	check_the_permissions();
+	check_the_nonce( $_POST['nonce'], 'safety-net-disable-webhooks' ); // phpcs:ignore WordPress.Security.NonceVerification
+
+	// Checks passed. Disable the webhooks.
+	disable_webhooks();
+
+	echo wp_json_encode(
+		array(
+			'success' => true,
+			'message' => esc_html__( 'Webhooks have been disabled.' ),
+		)
+	);
 }
 
 /**

--- a/includes/bootstrap.php
+++ b/includes/bootstrap.php
@@ -125,10 +125,5 @@ function maybe_disable_webhooks() {
 		return;
 	}
 
-	// If WooCommerce is not active, return.
-	if ( ! class_exists( 'woocommerce' ) ) {
-		return;
-	}
-
 	do_action( 'safety_net_disable_webhooks' );
 }

--- a/includes/bootstrap.php
+++ b/includes/bootstrap.php
@@ -13,6 +13,7 @@ add_action( 'safety_net_loaded', __NAMESPACE__ . '\maybe_scrub_options' );
 add_action( 'safety_net_loaded', __NAMESPACE__ . '\maybe_deactivate_plugins' );
 add_action( 'safety_net_loaded', __NAMESPACE__ . '\maybe_delete_data' );
 add_action( 'safety_net_loaded', __NAMESPACE__ . '\maybe_delete_transients' );
+add_action( 'safety_net_loaded', __NAMESPACE__ . '\maybe_disable_webhooks' );
 /**
  * Determines if we should set the 'Pause renewal actions' toggle when first loading the plugin.
  *
@@ -106,4 +107,28 @@ function maybe_delete_data() {
 
 	// Fire hooks to let plugin know to delete data.
 	do_action( 'safety_net_delete_data' );
+}
+
+/**
+ * Determines if webhooks should be disabled.
+ *
+ * Webhooks will be disabled if we're on staging, development, or local AND they haven't already been disabled.
+ */
+function maybe_disable_webhooks() {
+	// If webhooks have already been disabled, skip.
+	if ( get_option( 'safety_net_webhooks_disabled' ) ) {
+		return;
+	}
+
+	// If we're not on staging, development, or a local environment, return.
+	if ( is_production() ) {
+		return;
+	}
+
+	// If WooCommerce is not active, return.
+	if ( ! class_exists( 'woocommerce' ) ) {
+		return;
+	}
+
+	do_action( 'safety_net_disable_webhooks' );
 }

--- a/includes/classes/cli/class-safetynet-cli.php
+++ b/includes/classes/cli/class-safetynet-cli.php
@@ -67,6 +67,22 @@ class SafetyNet_CLI extends WP_CLI_Command {
 
 		WP_CLI::success( __( 'Problematic plugins have been deactivated.' ) );
 	}
+
+	/**
+	 * Disable all WooCommerce webhooks
+	 *
+	 * ## EXAMPLES
+	 *
+	 * wp safety-net disable-webhooks
+	 *
+	 * @subcommand disable-webhooks
+	 *
+	 */
+	public function disable_webhooks() {
+		\SafetyNet\DisableWebhooks\disable_webhooks();
+
+		WP_CLI::success( __( 'All WooCommerce webhooks have been disabled.' ) );
+	}
 }
 
 $instance = new SafetyNet_CLI();

--- a/includes/disable-webhooks.php
+++ b/includes/disable-webhooks.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace SafetyNet\DisableWebhooks;
+
+use function SafetyNet\Utilities\get_denylist_array;
+
+add_action( 'safety_net_disable_webhooks', __NAMESPACE__ . '\disable_webhooks' );
+
+/*
+* Deactivate plugins from a denylist
+*/
+function disable_webhooks() {
+	if ( get_option( 'safety_net_webhooks_disabled' ) ) {
+		return;
+	}
+
+	// The webhooks settings are part of WooCommerce
+	if ( class_exists( 'WC_Data_Store' ) ) {
+		$data_store = \WC_Data_Store::load( "webhook" );
+		$webhooks = $data_store->get_webhooks_ids( "" );
+		foreach ( $webhooks as $webhook_id ) {
+		  $webhook = \wc_get_webhook($webhook_id);
+		  if ($webhook->get_status() !== "disabled") {
+			$webhook->set_status("disabled");
+			$webhook->save();
+		  }
+		}
+	}
+	update_option( 'safety_net_webhooks_disabled', true );
+}

--- a/includes/disable-webhooks.php
+++ b/includes/disable-webhooks.php
@@ -10,21 +10,13 @@ add_action( 'safety_net_disable_webhooks', __NAMESPACE__ . '\disable_webhooks' )
 * Deactivate plugins from a denylist
 */
 function disable_webhooks() {
-	if ( get_option( 'safety_net_webhooks_disabled' ) ) {
-		return;
-	}
+	global $wpdb;
 
-	// The webhooks settings are part of WooCommerce
-	if ( class_exists( 'WC_Data_Store' ) ) {
-		$data_store = \WC_Data_Store::load( "webhook" );
-		$webhooks = $data_store->get_webhooks_ids( "" );
-		foreach ( $webhooks as $webhook_id ) {
-		  $webhook = \wc_get_webhook($webhook_id);
-		  if ($webhook->get_status() !== "disabled") {
-			$webhook->set_status("disabled");
-			$webhook->save();
-		  }
-		}
-	}
+	// Delete all transients
+	$wpdb->query( "UPDATE {$wpdb->prefix}wc_webhooks SET status = 'disabled'" );
+
+	// Set option so this function doesn't run again.
 	update_option( 'safety_net_webhooks_disabled', true );
+
+	wp_cache_flush();
 }

--- a/safety-net.php
+++ b/safety-net.php
@@ -2,7 +2,7 @@
 /*
  * Plugin Name: Safety Net
  * Description: For Team51 Development Sites. Deletes user data and more!
- * Version: 1.4.22
+ * Version: 1.4.23
  * Author: WordPress.com Special Projects
  * Author URI: https://wpspecialprojects.wordpress.com
  * Text Domain: safety-net

--- a/safety-net.php
+++ b/safety-net.php
@@ -29,6 +29,7 @@ require_once __DIR__ . '/includes/delete-transients.php';
 require_once __DIR__ . '/includes/utilities.php';
 require_once __DIR__ . '/includes/deactivate-plugins.php';
 require_once __DIR__ . '/includes/scrub-options.php';
+require_once __DIR__ . '/includes/disable-webhooks.php';
 
 if ( defined( 'WP_CLI' ) && WP_CLI ) {
 	require_once __DIR__ . '/includes/classes/cli/class-safetynet-cli.php';


### PR DESCRIPTION
Part of a permanent fix for https://github.com/a8cteam51/team51-dev-requests/issues/5365

Adds the disabling of [WooCommerce webhooks](https://woocommerce.com/document/webhooks/) to Safety Net.

- On activation, all webhooks will be disabled
- Like other Safety Net functions, an option (`safety_net_webhooks_disabled`) is added so that the function won't repeat if webhooks are enabled later.
- There is also an option on the Safety Net admin page to disable webhooks.
- A new CLI subcommand `wp safety-net disable-webhooks` is added.

### Testing

- Install WooCommerce on a test site
- Go to WooCommerce Webhooks settings (_WooCommerce -> Settings -> Advanced -> Webhooks_ or directly via the URI path `/wp-admin/admin.php?page=wc-settings&tab=advanced&section=webhooks`)
- Add some webhooks. They don't need to be valid, but should include Active, Disabled, and Paused webhooks.
- Install and activate Safety Net from this branch
- Confirm the webhooks have all been disabled
- Activate or set to Paused some of the webhooks
- Refresh and confirm they retain their status
- Go to the Safety Net settings (_Tools -> Safety Net_ or `/wp-admin/tools.php?page=safety_net_options`)
- Click the "Disable Webhooks" button
- Ensure you get a popup prompt
- Click "Cancel"
- Refresh the webhooks settings and ensure they've retained their status
- Click the "Disable Webhooks" button
- Click "OK"
- Refresh the webhooks settings and verify all webhooks are disabled
- Activate or set to Paused some of the webhooks
- From a command line, run `wp safety-net disable-webhooks`
- Refresh the webhooks settings and verify all webhooks are disabled
