### PR TITLE
Add support for `sandbox` env type

### DIFF
--- a/includes/admin.php
+++ b/includes/admin.php
@@ -5,9 +5,11 @@ namespace SafetyNet\Admin;
 use function SafetyNet\ScrubOptions\scrub_options;
 use function SafetyNet\DeactivatePlugins\deactivate_plugins;
 use function SafetyNet\Delete\delete_users_and_orders;
+use function SafetyNet\Utilities\get_environment_type;
 use function SafetyNet\Utilities\is_production;
 use function SafetyNet\DeleteTransients\delete_transients;
 use function SafetyNet\DisableWebhooks\disable_webhooks;
+
 add_filter( 'init', __NAMESPACE__ . '\add_admin_hooks' );
 
 /**
@@ -504,7 +506,7 @@ function show_warning() {
 		esc_html_e( 'WooCommerce Subscriptions scheduled actions are currently paused.', 'safety-net' );
 		echo '<br>';
 	}
-	echo 'This site\'s environment type is set to "' . esc_html( wp_get_environment_type() ) . '".';
+	echo 'This site\'s environment type is set to "' . esc_html( get_environment_type() ) . '".';
 	echo '</p></div>';
 }
 

--- a/includes/utilities.php
+++ b/includes/utilities.php
@@ -29,7 +29,7 @@ function is_production() {
 
     if ( 'production' === $current_env ) { // Either true production or fallback production due to an unsupported environment type.
         $other_supported_envs = array( 'sandbox', 'dev', 'develop' );
-        if ( defined( 'WP_ENVIRONMENT_TYPE' ) && WP_ENVIRONMENT_TYPE && in_array( WP_ENVIRONMENT_TYPE, $other_supported_envs, true ) ) {
+        if ( defined( 'WP_ENVIRONMENT_TYPE' ) && in_array( WP_ENVIRONMENT_TYPE, $other_supported_envs, true ) ) {
             $current_env = WP_ENVIRONMENT_TYPE;
         }
     }

--- a/includes/utilities.php
+++ b/includes/utilities.php
@@ -23,22 +23,22 @@ function get_admin_user_ids(): array {
  * @return string
  */
 function get_environment_type(): string {
-	$current_env = wp_get_environment_type();
+    $current_env = wp_get_environment_type();
 
-	if ( 'production' === $current_env ) { // Either true production or fallback production due to an unsupported environment type.
-		$other_supported_envs = array( 'sandbox', 'dev', 'develop' );
+    if ( 'production' === $current_env ) { // Either true production or fallback production due to an unsupported environment type.
+        $other_supported_envs = array( 'sandbox', 'dev', 'develop' );
 
-		if ( function_exists( 'getenv' ) ) {
-			$env = getenv( 'WP_ENVIRONMENT_TYPE' );
+        if ( function_exists( 'getenv' ) ) {
+            $env = getenv( 'WP_ENVIRONMENT_TYPE' );
             if ( in_array( $env, $other_supported_envs, true ) ) {
                 $current_env = $env;
             }
         }
 
-		if ( defined( 'WP_ENVIRONMENT_TYPE' ) && in_array( WP_ENVIRONMENT_TYPE, $other_supported_envs, true ) ) {
-			$current_env = WP_ENVIRONMENT_TYPE;
-		}
-	}
+        if ( defined( 'WP_ENVIRONMENT_TYPE' ) && in_array( WP_ENVIRONMENT_TYPE, $other_supported_envs, true ) ) {
+            $current_env = WP_ENVIRONMENT_TYPE;
+        }
+    }
 
     return $current_env;
 }

--- a/includes/utilities.php
+++ b/includes/utilities.php
@@ -14,27 +14,42 @@ function get_admin_user_ids(): array {
 }
 
 /**
- * Returns true if plugin is running on production.
- *
  * The function @{wp_get_environment_type()} from WP Core will default to 'production' if the environment type is set
  * to anything other than 'staging', 'development', or 'local'. However, some hosts like Pressable and tools like
  * WPCOM Studio set an unsupported environment type via the constant `WP_ENVIRONMENT_TYPE` (in both cases, `sandbox`).
  *
  * This function tries to reconcile that.
  *
+ * @return string
+ */
+function get_environment_type(): string {
+	$current_env = wp_get_environment_type();
+
+	if ( 'production' === $current_env ) { // Either true production or fallback production due to an unsupported environment type.
+		$other_supported_envs = array( 'sandbox', 'dev', 'develop' );
+
+		if ( function_exists( 'getenv' ) ) {
+			$env = getenv( 'WP_ENVIRONMENT_TYPE' );
+            if ( in_array( $env, $other_supported_envs, true ) ) {
+                $current_env = $env;
+            }
+        }
+
+		if ( defined( 'WP_ENVIRONMENT_TYPE' ) && in_array( WP_ENVIRONMENT_TYPE, $other_supported_envs, true ) ) {
+			$current_env = WP_ENVIRONMENT_TYPE;
+		}
+	}
+
+    return $current_env;
+}
+
+/**
+ * Returns true if plugin is running on production.
+ *
  * @return boolean
  */
 function is_production() {
-    $current_env = wp_get_environment_type();
-
-    if ( 'production' === $current_env ) { // Either true production or fallback production due to an unsupported environment type.
-        $other_supported_envs = array( 'sandbox', 'dev', 'develop' );
-        if ( defined( 'WP_ENVIRONMENT_TYPE' ) && in_array( WP_ENVIRONMENT_TYPE, $other_supported_envs, true ) ) {
-            $current_env = WP_ENVIRONMENT_TYPE;
-        }
-    }
-
-    return 'production' === $current_env;
+    return 'production' === get_environment_type();
 }
 
 /**

--- a/includes/utilities.php
+++ b/includes/utilities.php
@@ -14,15 +14,27 @@ function get_admin_user_ids(): array {
 }
 
 /**
- * Returns true if plugin is running on production
+ * Returns true if plugin is running on production.
+ *
+ * The function @{wp_get_environment_type()} from WP Core will default to 'production' if the environment type is set
+ * to anything other than 'staging', 'development', or 'local'. However, some hosts like Pressable and tools like
+ * WPCOM Studio set an unsupported environment type via the constant `WP_ENVIRONMENT_TYPE` (in both cases, `sandbox`).
+ *
+ * This function tries to reconcile that.
  *
  * @return boolean
  */
 function is_production() {
-	// If we're not on staging, development, or a local environment, return true.
-	if ( ! in_array( wp_get_environment_type(), array( 'staging', 'development', 'local' ), true ) ) {
-		return true;
-	}
+    $current_env = wp_get_environment_type();
+
+    if ( 'production' === $current_env ) { // Either true production or fallback production due to an unsupported environment type.
+        $other_supported_envs = array( 'sandbox', 'dev', 'develop' );
+        if ( defined( 'WP_ENVIRONMENT_TYPE' ) && WP_ENVIRONMENT_TYPE && in_array( WP_ENVIRONMENT_TYPE, $other_supported_envs, true ) ) {
+            $current_env = WP_ENVIRONMENT_TYPE;
+        }
+    }
+
+    return 'production' === $current_env;
 }
 
 /**


### PR DESCRIPTION
Pressable's new sandbox sites use the `WP_ENVIRONMENT_TYPE` set to `sandbox`. Our code didn't take that into account, and this patch will.