### PR TITLE
Add support for "Publish to Apple News"

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,3 +106,9 @@ add_action( 'safety_net_loaded', __NAMESPACE__ . '\maybe_delete_data' )
 * Deletes user meta related to PMPro billing, like the billing address or Stripe customer ID.
 * Deletes all database entries related to membership orders & subscriptions, including coupon usage.
 * Disables all cron jobs related to PMPro.
+
+### Publish to Apple News
+
+* Scrubs the API access settings.
+* Disables API sync on WP post status updates.
+

--- a/README.md
+++ b/README.md
@@ -111,4 +111,5 @@ add_action( 'safety_net_loaded', __NAMESPACE__ . '\maybe_delete_data' )
 
 * Scrubs the API access settings.
 * Disables API sync on WP post status updates.
+* Disables the outgoing debugging email.
 

--- a/assets/data/option_scrublist.txt
+++ b/assets/data/option_scrublist.txt
@@ -70,3 +70,4 @@ zmail_integ_client_secret
 zmail_refresh_token
 passport_api_key
 passport_api_secret
+apple_news_settings

--- a/assets/data/option_scrublist.txt
+++ b/assets/data/option_scrublist.txt
@@ -1,3 +1,4 @@
+apple_news_settings
 jetpack_active_modules
 jetpack_private_options
 jetpack_secrets
@@ -47,6 +48,8 @@ pmpro_transactionkey
 pmpro_twocheckout_accountnumber
 pmpro_twocheckout_apipassword
 pmpro_twocheckout_apiusername
+passport_api_key
+passport_api_secret
 shareasale_wc_tracker_options
 woocommerce-ppcp-settings
 woocommerce_afterpay_settings
@@ -68,6 +71,3 @@ zmail_access_token
 zmail_auth_code
 zmail_integ_client_secret
 zmail_refresh_token
-passport_api_key
-passport_api_secret
-apple_news_settings

--- a/assets/data/plugin_denylist.txt
+++ b/assets/data/plugin_denylist.txt
@@ -45,4 +45,3 @@ wpmandrill
 yotpo
 zapier
 zoho-mail
-publish-to-apple-news

--- a/assets/data/plugin_denylist.txt
+++ b/assets/data/plugin_denylist.txt
@@ -45,3 +45,4 @@ wpmandrill
 yotpo
 zapier
 zoho-mail
+publish-to-apple-news

--- a/includes/scrub-options.php
+++ b/includes/scrub-options.php
@@ -100,6 +100,21 @@ function scrub_options() {
 				}
 
 				safety_net_update_option_direct( $option, $option_array );
+			} elseif ( 'apple_news_settings' === $option ) {
+				$keys_to_scrub = array( 'api_key', 'api_secret', 'api_channel' );
+
+				$option_array = $option_value;
+				foreach ( $keys_to_scrub as $key ) {
+					if ( array_key_exists( $key, $option_array ) ) {
+						$option_array[ $key ] = '';
+					}
+				}
+
+				$option_array['api_autosync'] = 'no';
+				$option_array['api_autosync_update']  = 'no';
+				$option_array['api_autosync_delete']  = 'no';
+
+				safety_net_update_option_direct( $option, $option_array );
 			} else {
 				// Some plugins don't like it when options are deleted, so we will save their value as either an empty string or array, depending on which it already is.
 				if ( is_array( get_option( $option ) ) ) {

--- a/includes/scrub-options.php
+++ b/includes/scrub-options.php
@@ -112,7 +112,9 @@ function scrub_options() {
 
 				$option_array['api_autosync'] = 'no';
 				$option_array['api_autosync_update']  = 'no';
+				$option_array['api_autosync_trash'] = 'no';
 				$option_array['api_autosync_delete']  = 'no';
+				$option_array['api_autosync_unpublish'] = 'no';
 
 				safety_net_update_option_direct( $option, $option_array );
 			} else {

--- a/includes/scrub-options.php
+++ b/includes/scrub-options.php
@@ -101,7 +101,7 @@ function scrub_options() {
 
 				safety_net_update_option_direct( $option, $option_array );
 			} elseif ( 'apple_news_settings' === $option ) {
-				$keys_to_scrub = array( 'api_key', 'api_secret', 'api_channel' );
+				$keys_to_scrub = array( 'api_key', 'api_secret', 'api_channel', 'apple_news_admin_email' );
 
 				$option_array = $option_value;
 				foreach ( $keys_to_scrub as $key ) {
@@ -115,6 +115,8 @@ function scrub_options() {
 				$option_array['api_autosync_trash'] = 'no';
 				$option_array['api_autosync_delete']  = 'no';
 				$option_array['api_autosync_unpublish'] = 'no';
+
+				$option_array['apple_news_enable_debugging'] = 'no';
 
 				safety_net_update_option_direct( $option, $option_array );
 			} else {


### PR DESCRIPTION
SafetyNet will disable the plugin and scrub the API keys from the settings while keeping the settings array mostly intact. Moreover, it disabled auto-syncing via the API.

For reference: https://github.com/alleyinteractive/apple-news/blob/develop/includes/apple-exporter/class-settings.php

Mentions #160 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced scrubbing for Apple News: sensitive API keys cleared and autosync options disabled, with changes persisted.

* **Documentation**
  * Added "Publish to Apple News" instructions explaining scrubbing, disabling API sync on post status updates, and suppressing debug email.

* **Chores**
  * Updated option scrublist to include Apple News and two passport-related keys and adjusted entry order.
  * Minor tidy: ensured plugin denylist ends with a newline.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->