### PR TITLE
Add support for ConvertKit

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,13 +91,18 @@ add_action( 'safety_net_loaded', __NAMESPACE__ . '\maybe_delete_data' )
 
 ## Explanations
 
+### BuddyPress
+
+* Deletes user profiles, friends, messages, and notifications.
+
+### Kit (formerly ConvertKit)
+
+* Scrubs the API access settings.
+* Disables the plugin.
+
 ### PMPro
 
 * Scrubs all database keys containing API keys for payment gateways.
 * Deletes user meta related to PMPro billing, like the billing address or Stripe customer ID.
 * Deletes all database entries related to membership orders & subscriptions, including coupon usage.
 * Disables all cron jobs related to PMPro.
-
-### BuddyPress
-
-* Deletes user profiles, friends, messages, and notifications.

--- a/assets/data/option_scrublist.txt
+++ b/assets/data/option_scrublist.txt
@@ -60,6 +60,7 @@ woocommerce_stripe_account_settings
 woocommerce_stripe_api_settings
 woocommerce_stripe_settings
 woocommerce_woocommerce_payments_settings
+_wp_convertkit_settings
 wpmandrill
 wprus
 yotpo_settings

--- a/assets/data/plugin_denylist.txt
+++ b/assets/data/plugin_denylist.txt
@@ -5,6 +5,7 @@ automatewoo
 automator
 avatax
 console
+convertkit
 distributor
 hubspot
 in-stock-mailer-for-wc

--- a/includes/scrub-options.php
+++ b/includes/scrub-options.php
@@ -89,6 +89,15 @@ function scrub_options() {
 				if ( function_exists( 'pmpro_clear_crons' ) ) {
 					pmpro_clear_crons();
 				}
+			} else if ( '_wp_convertkit_settings' === $option ) {
+				$keys_to_scrub = array( 'access_token', 'refresh_token', 'token_expires', 'api_key', 'api_secret' );
+				foreach ( $keys_to_scrub as $key ) {
+					if ( array_key_exists( $key, $option_array ) ) {
+						$option_array[ $key ] = '';
+					}
+				}
+
+				safety_net_update_option_direct( $option, $option_array );
 			} else {
 				// Some plugins don't like it when options are deleted, so we will save their value as either an empty string or array, depending on which it already is.
 				if ( is_array( get_option( $option ) ) ) {

--- a/includes/scrub-options.php
+++ b/includes/scrub-options.php
@@ -90,6 +90,8 @@ function scrub_options() {
 					pmpro_clear_crons();
 				}
 			} else if ( '_wp_convertkit_settings' === $option ) {
+				$option_array  = $option_value;
+
 				$keys_to_scrub = array( 'access_token', 'refresh_token', 'token_expires', 'api_key', 'api_secret' );
 				foreach ( $keys_to_scrub as $key ) {
 					if ( array_key_exists( $key, $option_array ) ) {

--- a/safety-net.php
+++ b/safety-net.php
@@ -2,7 +2,7 @@
 /*
  * Plugin Name: Safety Net
  * Description: For Team51 Development Sites. Deletes user data and more!
- * Version: 1.5.4
+ * Version: 1.5.5
  * Author: WordPress.com Special Projects
  * Author URI: https://wpspecialprojects.wordpress.com
  * Text Domain: safety-net


### PR DESCRIPTION
SafetyNet will disable the plugin and scrub the API keys from the settings while keeping the settings array mostly intact. 

For reference: https://github.com/Kit/convertkit-wordpress/blob/main/includes/class-convertkit-settings.php#L458

Mentions #115 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Scrubs sensitive ConvertKit settings to protect user privacy (clears access tokens and API credentials).

- **Documentation**
  - Added overview notes for ConvertKit (Kit) scrubbing and guidance on disabling the plugin; reorganized explanation sections.

- **Chores**
  - Updated internal deny/scrub lists to include ConvertKit entries and bumped the release version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->