### PR TITLE
Don't delete GiveWP donation forms

### DIFF
--- a/includes/delete.php
+++ b/includes/delete.php
@@ -118,8 +118,6 @@ function delete_users_and_orders() {
 	}
 
 	// Delete Give payment and donation posts
-	$wpdb->query( "DELETE FROM $wpdb->postmeta WHERE post_id IN ( SELECT ID FROM {$wpdb->posts} WHERE post_type = 'give_forms' )" );
-	$wpdb->query( "DELETE FROM $wpdb->posts WHERE post_type = 'give_forms'" );
 	$wpdb->query( "DELETE FROM $wpdb->postmeta WHERE post_id IN ( SELECT ID FROM {$wpdb->posts} WHERE post_type = 'give_payment' )" );
 	$wpdb->query( "DELETE FROM $wpdb->posts WHERE post_type = 'give_payment'" );
 


### PR DESCRIPTION
Removes the logic for deleting GiveWP donation forms, because only donor data needs to be removed, not the forms themselves.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Stopped deleting "give_forms" and their related data during user and order deletion processes. Only "give_payment" entries are now removed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->