### PR TITLE
Skip givewp data delete

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,16 @@ This public plugin is provided as an example of how such a plugin could be imple
 #### Advanced features
 - **CLI commands**: CLI equivalents of the above features: `wp safety-net scrub-options`, `wp safety-net deactivate-plugins`, and `wp safety-net delete`
 
+### Skipping GiveWP Data Deletion
+
+By default, Safety Net will delete GiveWP donor data, payment records, and subscriptions when running the data deletion process. If you want to **preserve GiveWP data on a staging site**, you can define the following constant in your `wp-config.php` file:
+
+```php
+define( 'SAFETY_NET_SKIP_GIVEWP', true );
+```
+
+When this constant is set to `true`, all GiveWP-specific data will be excluded from the deletion process. This includes donor records, donation posts, subscription data, and related metadata.
+
 ## Planned Features
 - Multi-site (WordPress network) compatibility
 - Do you have a suggestion for the next great feature to add? Please create an issue or submit a PR!

--- a/includes/delete.php
+++ b/includes/delete.php
@@ -105,21 +105,23 @@ function delete_users_and_orders() {
     }
 
 	// Delete Give plugin data
-	$table_name = $wpdb->prefix . 'give_donors';
-	if ( $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $table_name ) ) === $table_name ) {
-		$wpdb->query( "DELETE FROM {$wpdb->prefix}give_donors" );
-		$wpdb->query( "DELETE FROM {$wpdb->prefix}give_donormeta" );
-		$wpdb->query( "DELETE FROM {$wpdb->prefix}give_donationmeta" );
-		$wpdb->query( "DELETE FROM {$wpdb->prefix}give_comments" );
-		$wpdb->query( "DELETE FROM {$wpdb->prefix}give_commentmeta" );
-		$wpdb->query( "DELETE FROM {$wpdb->prefix}give_sessions" );
-		$wpdb->query( "DELETE FROM {$wpdb->prefix}give_subscriptions" );
-		$wpdb->query( "DELETE FROM {$wpdb->prefix}give_subscriptionmeta" );
-	}
+	if ( ! defined( 'SAFETY_NET_SKIP_GIVEWP' ) || SAFETY_NET_SKIP_GIVEWP !== true ) {
+		$table_name = $wpdb->prefix . 'give_donors';
+		if ( $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $table_name ) ) === $table_name ) {
+			$wpdb->query( "DELETE FROM {$wpdb->prefix}give_donors" );
+			$wpdb->query( "DELETE FROM {$wpdb->prefix}give_donormeta" );
+			$wpdb->query( "DELETE FROM {$wpdb->prefix}give_donationmeta" );
+			$wpdb->query( "DELETE FROM {$wpdb->prefix}give_comments" );
+			$wpdb->query( "DELETE FROM {$wpdb->prefix}give_commentmeta" );
+			$wpdb->query( "DELETE FROM {$wpdb->prefix}give_sessions" );
+			$wpdb->query( "DELETE FROM {$wpdb->prefix}give_subscriptions" );
+			$wpdb->query( "DELETE FROM {$wpdb->prefix}give_subscriptionmeta" );
+		}
 
-	// Delete Give payment and donation posts
-	$wpdb->query( "DELETE FROM $wpdb->postmeta WHERE post_id IN ( SELECT ID FROM {$wpdb->posts} WHERE post_type = 'give_payment' )" );
-	$wpdb->query( "DELETE FROM $wpdb->posts WHERE post_type = 'give_payment'" );
+		// Delete Give payment and donation posts
+		$wpdb->query( "DELETE FROM $wpdb->postmeta WHERE post_id IN ( SELECT ID FROM {$wpdb->posts} WHERE post_type = 'give_payment' )" );
+		$wpdb->query( "DELETE FROM $wpdb->posts WHERE post_type = 'give_payment'" );
+	}
 
 	// Reassigning all posts to the first admin user
 	reassign_all_posts();

--- a/safety-net.php
+++ b/safety-net.php
@@ -2,7 +2,7 @@
 /*
  * Plugin Name: Safety Net
  * Description: For Team51 Development Sites. Deletes user data and more!
- * Version: 1.4.29
+ * Version: 1.5.0
  * Author: WordPress.com Special Projects
  * Author URI: https://wpspecialprojects.wordpress.com
  * Text Domain: safety-net


### PR DESCRIPTION
## Summary

This PR adds support for skipping the deletion of GiveWP donor and payment data when running the Safety Net deletion process.

Developers can now opt out of deleting GiveWP-related data on staging or development environments by defining a constant in their `wp-config.php` file:

```php
define( 'SAFETY_NET_SKIP_GIVEWP', true );
````

When this constant is present and explicitly set to `true`, the plugin will skip deleting GiveWP data.

If the constant is not defined or is set to anything other than `true`, the data will be deleted as usual.

---

## Why?

Some staging or QA environments may need to retain donor records while still scrubbing user data and orders from other plugins like WooCommerce. This PR makes GiveWP data deletion optional.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an option to skip deletion of GiveWP donor data, payment records, and subscriptions by setting a configuration constant.
* **Documentation**
  * Updated the README with instructions on how to preserve GiveWP data during the data deletion process.
* **Chores**
  * Updated the plugin version to 1.5.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->