### PR TITLE
Include the ActionScheduler class as soon as possible

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ vendor/
 .DS_Store
 node_modules/
 .idea
+
+# Local History for Visual Studio Code
+.history/

--- a/includes/admin.php
+++ b/includes/admin.php
@@ -10,6 +10,22 @@ use function SafetyNet\Utilities\is_production;
 use function SafetyNet\DeleteTransients\delete_transients;
 use function SafetyNet\DisableWebhooks\disable_webhooks;
 
+// Register the custom store class filter IMMEDIATELY when this file loads.
+if ( 'on' === get_option( 'safety_net_pause_renewal_actions_toggle' ) ) {
+    add_filter(
+        'action_scheduler_store_class',
+        function ( $class ) {
+            // Load the custom class file only when Action Scheduler requests it.
+            if ( ! class_exists( 'SafetyNet\ActionScheduler_Custom_DBStore' ) ) {
+                require_once __DIR__ . '/classes/class-actionscheduler-custom-dbstore.php';
+            }
+            return 'SafetyNet\ActionScheduler_Custom_DBStore';
+        },
+        101,
+        1
+    );
+}
+
 add_filter( 'init', __NAMESPACE__ . '\add_admin_hooks' );
 
 /**
@@ -31,7 +47,6 @@ function add_admin_hooks() {
 		add_action( 'wp_ajax_safety_net_disable_webhooks', __NAMESPACE__ . '\handle_ajax_disable_webhooks' );
 		add_filter( 'plugin_action_links_' . SAFETY_NET_BASENAME, __NAMESPACE__ . '\add_action_links' );
 	}
-	add_action( 'action_scheduler_pre_init', __NAMESPACE__ . '\pause_renewal_actions' );
 	add_action( 'admin_notices', __NAMESPACE__ . '\show_warning' );
 	add_filter( 'pre_wp_mail', __NAMESPACE__ . '\stop_emails', 10, 2 );
 }
@@ -466,24 +481,6 @@ function add_action_links( $actions ) {
 	);
 
 	return array_merge( $actions, $links );
-}
-
-/**
- * Pause WooCommerce Subscriptions renewal and failed payment retry scheduled actions
- *
- */
-function pause_renewal_actions() {
-	if ( 'on' === get_option( 'safety_net_pause_renewal_actions_toggle' ) ) {
-		require_once __DIR__ . '/classes/class-actionscheduler-custom-dbstore.php';
-		add_filter(
-			'action_scheduler_store_class',
-			function ( $class ) {
-				return 'SafetyNet\ActionScheduler_Custom_DBStore';
-			},
-			101,
-			1
-		);
-	}
 }
 
 /**

--- a/safety-net.php
+++ b/safety-net.php
@@ -2,7 +2,7 @@
 /*
  * Plugin Name: Safety Net
  * Description: For Team51 Development Sites. Deletes user data and more!
- * Version: 1.5.0
+ * Version: 1.5.1
  * Author: WordPress.com Special Projects
  * Author URI: https://wpspecialprojects.wordpress.com
  * Text Domain: safety-net


### PR DESCRIPTION
### Changes proposed in this PR
Safety Net aims to pause WooCommerce Subscriptions renewal and retry actions by overriding the Action Scheduler store class with a custom implementation. However, the previous approach attempted to register the custom store class filter or load the custom class too late in the WordPress/plugin lifecycle. This resulted in one or more of the following issues:
- The custom store class was not used, so subscription renewals were not paused as intended.
- Fatal errors occurred if the custom class was loaded before Action Scheduler’s own classes were available.

### What was done:

The `action_scheduler_store_class` filter is now registered immediately when the plugin loads, not on a hook. This ensures the filter is in place before Action Scheduler instantiates its store class (which happens on the first use, after all plugins are loaded but before most hooks).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated internal configuration to better manage local development files and Visual Studio Code local history.
* **Refactor**
  * Enhanced the registration process of a custom Action Scheduler store for improved performance without affecting user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->