### PR TITLE
Change how we distribute the zip in a release

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+# Directories
+/.git export-ignore
+/.github export-ignore
+
+# Files
+/.* export-ignore
+/README.md export-ignore

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,15 +10,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout repository
+        uses: actions/checkout@v4
 
-      - name: Zip Folder
-        run: zip -r ${{ github.event.repository.name }}.zip . -x ".git/*" ".github/*" ".gitignore"
+      - name: Zip folder
+        run: git archive --prefix=${{ github.event.repository.name }}/ HEAD -o ${{ github.event.repository.name }}.zip
 
       - name: Release
-        uses: softprops/action-gh-release@v1
-        if: startsWith(github.ref, 'refs/tags/')
+        uses: softprops/action-gh-release@v2
         with:
           files: ${{ github.event.repository.name }}.zip
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/safety-net.php
+++ b/safety-net.php
@@ -2,7 +2,7 @@
 /*
  * Plugin Name: Safety Net
  * Description: For Team51 Development Sites. Deletes user data and more!
- * Version: 1.5.1
+ * Version: 1.5.2
  * Author: WordPress.com Special Projects
  * Author URI: https://wpspecialprojects.wordpress.com
  * Text Domain: safety-net


### PR DESCRIPTION
To comply with Pressable's platform standards, the update to the `release.yml` action ensures that the `.zip` file attached to a release will extract into a `safety-net` directory containing our source code. Previously, unzipping the asset would place all files directly into the current directory.

The main addition in this PR is the `.gitattributes` file that works in conjunction with `git archive`. It basically replaces what we were doing with `zip`then `-x` (excluding some folders, e.g. `.git`, `.github`)

The actions were also updated to `v4` and `v2`, for `actions/checkout` and `softprops/action-gh-release`, respectively.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated release workflow to use newer versions of GitHub Actions and improved the method for creating release archives.
  * Introduced a configuration to exclude certain files and directories (such as hidden files and documentation) from exported archives.
  * Bumped plugin version number from 1.5.1 to 1.5.2.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->