### PR TITLE
Disable pingbacks

### DIFF
--- a/assets/data/option_scrublist.txt
+++ b/assets/data/option_scrublist.txt
@@ -1,4 +1,5 @@
 apple_news_settings
+default_pingback_flag
 jetpack_active_modules
 jetpack_private_options
 jetpack_secrets

--- a/includes/scrub-options.php
+++ b/includes/scrub-options.php
@@ -119,6 +119,14 @@ function scrub_options() {
 				$option_array['apple_news_enable_debugging'] = 'no';
 
 				safety_net_update_option_direct( $option, $option_array );
+			} elseif ( 'default_pingback_flag' === $option ) {
+				// Delete all _pingme postmeta to prevent pingbacks from being sent.
+				$wpdb->delete(
+					$wpdb->postmeta,
+					array( 'meta_key' => '_pingme' )
+				);
+
+				safety_net_update_option_direct( $option, '' );
 			} else {
 				// Some plugins don't like it when options are deleted, so we will save their value as either an empty string or array, depending on which it already is.
 				if ( is_array( get_option( $option ) ) ) {


### PR DESCRIPTION
Resolves #153.

Scrubs the `default_pingback_flag` option.

## Testing Instructions
1. In _Settings_ > _Discussion_, ensure the _Attempt to notify any blogs linked to from the post_ is checked.
2. Delete the `safety_net_options_scrubbed` option from the `wp_options` table.
3. In _Tools_ > _Safety Net_, click the _Scrub Options_ button.
4. In _Settings_ > _Discussion_, ensure the _Attempt to notify any blogs linked to from the post_ is **unchecked**.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a new option to the scrub list to expand cleaned configuration entries.
* **Bug Fixes / Cleanup**
  * When that option is present, related legacy post metadata is removed and the option value is cleared to ensure consistent cleanup and prevent stale settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds handling to scrub `default_pingback_flag` and bulk-delete `_pingme` postmeta to prevent pingbacks.
> 
> - **Scrub logic**:
>   - In `includes/scrub-options.php`, add case for `default_pingback_flag`:
>     - Delete all postmeta with `meta_key` `_pingme`.
>     - Clear the `default_pingback_flag` option.
> - **Data**:
>   - Add `default_pingback_flag` to `assets/data/option_scrublist.txt`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 654fbc354f38f0546c784b752b0554715f518dff. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->