### PR TITLE
Add Cash App and Square to Safety Net Payment Gateway Deny List

### DIFF
--- a/assets/data/plugin_denylist.txt
+++ b/assets/data/plugin_denylist.txt
@@ -34,7 +34,9 @@ socketlabs
 sparkpost
 stripe
 webgility
+wc-cashapp
 woocommerce-zapier
+woocommerce-square
 wp-remote-users-sync
 wp-ses
 wp-to-buffer-pro

--- a/safety-net.php
+++ b/safety-net.php
@@ -2,33 +2,33 @@
 /*
  * Plugin Name: Safety Net
  * Description: For Team51 Development Sites. Deletes user data and more!
- * Version: 1.5.2
+ * Version: 1.5.3
  * Author: WordPress.com Special Projects
  * Author URI: https://wpspecialprojects.wordpress.com
  * Text Domain: safety-net
  * License: GPLv3
 */
 
-if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Exit if accessed directly
+if (! defined('ABSPATH') ) {
+    exit; // Exit if accessed directly
 }
 
-if ( defined( 'SAFETY_NET_PATH' ) ) {
-	return; // Return if another copy of the plugin is activated
+if (defined('SAFETY_NET_PATH') ) {
+    return; // Return if another copy of the plugin is activated
 }
 
-define( 'SAFETY_NET_PATH', plugin_dir_path( __FILE__ ) );
-define( 'SAFETY_NET_URL', plugin_dir_url( __FILE__ ) );
-define( 'SAFETY_NET_BASENAME', plugin_basename( __FILE__ ) );
+define('SAFETY_NET_PATH', plugin_dir_path(__FILE__));
+define('SAFETY_NET_URL', plugin_dir_url(__FILE__));
+define('SAFETY_NET_BASENAME', plugin_basename(__FILE__));
 
 // Allow access to the basic utility functions.
 require_once __DIR__ . '/includes/utilities.php';
 
 // If the site is production, bail.
-if ( SafetyNet\Utilities\is_production() ) {
-	// Show the production notice.
-	add_action( 'admin_notices', 'SafetyNet\Utilities\show_production_notice' );
-	return;
+if (SafetyNet\Utilities\is_production() ) {
+    // Show the production notice.
+    add_action('admin_notices', 'SafetyNet\Utilities\show_production_notice');
+    return;
 }
 
 require_once __DIR__ . '/includes/admin.php';
@@ -40,9 +40,9 @@ require_once __DIR__ . '/includes/deactivate-plugins.php';
 require_once __DIR__ . '/includes/scrub-options.php';
 require_once __DIR__ . '/includes/disable-webhooks.php';
 
-if ( defined( 'WP_CLI' ) && WP_CLI ) {
-	require_once __DIR__ . '/includes/classes/cli/class-safetynet-cli.php';
+if (defined('WP_CLI') && WP_CLI ) {
+    include_once __DIR__ . '/includes/classes/cli/class-safetynet-cli.php';
 }
 
 // Fire a hook now that the plugin is ready.
-do_action( 'safety_net_loaded' );
+do_action('safety_net_loaded');

--- a/safety-net.php
+++ b/safety-net.php
@@ -2,7 +2,7 @@
 /*
  * Plugin Name: Safety Net
  * Description: For Team51 Development Sites. Deletes user data and more!
- * Version: 1.5.2
+ * Version: 1.5.3
  * Author: WordPress.com Special Projects
  * Author URI: https://wpspecialprojects.wordpress.com
  * Text Domain: safety-net

--- a/safety-net.php
+++ b/safety-net.php
@@ -2,33 +2,33 @@
 /*
  * Plugin Name: Safety Net
  * Description: For Team51 Development Sites. Deletes user data and more!
- * Version: 1.5.3
+ * Version: 1.5.2
  * Author: WordPress.com Special Projects
  * Author URI: https://wpspecialprojects.wordpress.com
  * Text Domain: safety-net
  * License: GPLv3
 */
 
-if (! defined('ABSPATH') ) {
-    exit; // Exit if accessed directly
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly
 }
 
-if (defined('SAFETY_NET_PATH') ) {
-    return; // Return if another copy of the plugin is activated
+if ( defined( 'SAFETY_NET_PATH' ) ) {
+	return; // Return if another copy of the plugin is activated
 }
 
-define('SAFETY_NET_PATH', plugin_dir_path(__FILE__));
-define('SAFETY_NET_URL', plugin_dir_url(__FILE__));
-define('SAFETY_NET_BASENAME', plugin_basename(__FILE__));
+define( 'SAFETY_NET_PATH', plugin_dir_path( __FILE__ ) );
+define( 'SAFETY_NET_URL', plugin_dir_url( __FILE__ ) );
+define( 'SAFETY_NET_BASENAME', plugin_basename( __FILE__ ) );
 
 // Allow access to the basic utility functions.
 require_once __DIR__ . '/includes/utilities.php';
 
 // If the site is production, bail.
-if (SafetyNet\Utilities\is_production() ) {
-    // Show the production notice.
-    add_action('admin_notices', 'SafetyNet\Utilities\show_production_notice');
-    return;
+if ( SafetyNet\Utilities\is_production() ) {
+	// Show the production notice.
+	add_action( 'admin_notices', 'SafetyNet\Utilities\show_production_notice' );
+	return;
 }
 
 require_once __DIR__ . '/includes/admin.php';
@@ -40,9 +40,9 @@ require_once __DIR__ . '/includes/deactivate-plugins.php';
 require_once __DIR__ . '/includes/scrub-options.php';
 require_once __DIR__ . '/includes/disable-webhooks.php';
 
-if (defined('WP_CLI') && WP_CLI ) {
-    include_once __DIR__ . '/includes/classes/cli/class-safetynet-cli.php';
+if ( defined( 'WP_CLI' ) && WP_CLI ) {
+	require_once __DIR__ . '/includes/classes/cli/class-safetynet-cli.php';
 }
 
 // Fire a hook now that the plugin is ready.
-do_action('safety_net_loaded');
+do_action( 'safety_net_loaded' );


### PR DESCRIPTION
## Summary
This PR updates the Safety Net plugin to explicitly disable the Cash App and Square payment gateways. 

Mentions #169 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Bumped plugin version to 1.5.3.
  - Expanded the plugin denylist to include wc-cashapp and woocommerce-square; these plugins will now be blocked when detected.
  - No other functional changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->