### PR TITLE
Add Plugin URI to plugin header

### DIFF
--- a/safety-net.php
+++ b/safety-net.php
@@ -1,6 +1,7 @@
 <?php
 /*
  * Plugin Name: Safety Net
+ * Plugin URI: https://specialprojects.automattic.com/tools/safety-net/
  * Description: For Team51 Development Sites. Deletes user data and more!
  * Version: 1.5.5
  * Author: WordPress.com Special Projects

--- a/safety-net.php
+++ b/safety-net.php
@@ -5,7 +5,7 @@
  * Description: For Team51 Development Sites. Deletes user data and more!
  * Version: 1.5.5
  * Author: WordPress.com Special Projects
- * Author URI: https://wpspecialprojects.wordpress.com
+ * Author URI: https://specialprojects.automattic.com
  * Text Domain: safety-net
  * License: GPLv3
 */


### PR DESCRIPTION
Adds a Plugin URI to the plugin's header that goes to https://specialprojects.automattic.com/tools/safety-net/.

![Screenshot 2025-09-03 at 11 24 40 AM](https://github.com/user-attachments/assets/30756fcc-b14d-42d5-998a-570b13f77eff)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* Documentation
  * Added a Plugin URI in the plugin header so the Plugins screen links directly to the plugin homepage for info, docs, and updates.

* Chores
  * Updated author/site metadata to a new official URL for improved discoverability and consistency. No functional changes or user-facing behavior were altered.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->