### PR TITLE
Add cache clear function

### DIFF
--- a/includes/bootstrap.php
+++ b/includes/bootstrap.php
@@ -14,6 +14,8 @@ add_action( 'safety_net_loaded', __NAMESPACE__ . '\maybe_deactivate_plugins' );
 add_action( 'safety_net_loaded', __NAMESPACE__ . '\maybe_delete_data' );
 add_action( 'safety_net_loaded', __NAMESPACE__ . '\maybe_delete_transients' );
 add_action( 'safety_net_loaded', __NAMESPACE__ . '\maybe_disable_webhooks' );
+add_action( 'safety_net_loaded', __NAMESPACE__ . '\maybe_delete_caches' );
+
 /**
  * Determines if we should set the 'Pause renewal actions' toggle when first loading the plugin.
  *
@@ -126,4 +128,29 @@ function maybe_disable_webhooks() {
 	}
 
 	do_action( 'safety_net_disable_webhooks' );
+}
+
+/**
+ * Determines if caches should be deleted.
+ *
+ * Caches will be deleted if we're on staging, development, or local AND they haven't already been deleted.
+ *
+ * This is related to WooCommerce Subscriptions caches.
+ *
+ * @link https://woocommerce.com/document/subscriptions/develop/cache/
+ * 
+ * @return void
+ */
+function maybe_delete_caches() {
+	// If caches have already been deleted, skip.
+	if ( get_option( 'safety_net_caches_deleted' ) ) {
+		return;
+	}
+
+	// If we're not on staging, development, or a local environment, return.
+	if ( is_production() ) {
+		return;
+	}
+
+	do_action( 'safety_net_delete_caches' );
 }

--- a/includes/delete-related-order-caches.php
+++ b/includes/delete-related-order-caches.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace SafetyNet\DeletedRelatedOrderCaches;
+
+add_action( 'safety_net_delete_caches', __NAMESPACE__ . '\delete_all_subscription_caches' );
+
+/**
+ * This deletes the related order caches for subscriptions and users.
+ *
+ * @link https://woocommerce.com/document/subscriptions/develop/cache/#subscription-related-order-cache
+ * @link https://woocommerce.com/document/subscriptions/develop/cache/#customer-s-subscription-cache
+ *
+ * @return void
+ */
+function delete_all_subscription_caches() {
+	/** @var \wpdb $wpdb */
+	global $wpdb;
+
+	// 1. Delete customer subscription IDs cache
+	$customer_cache_key = '_wcs_subscription_ids_cache';
+
+	// For multisite, append blog ID
+	if ( is_multisite() ) {
+		$customer_cache_key .= '_' . get_current_blog_id();
+	}
+
+	// Delete from wp_usermeta
+	delete_metadata( 'user', null, $customer_cache_key, '', true );
+
+	// 2. Delete related order caches
+	$related_order_cache_keys = array(
+		'_subscription_renewal_order_ids_cache',
+		'_subscription_switch_order_ids_cache',
+		'_subscription_resubscribe_order_ids_cache',
+	);
+
+	// Delete data from the High Performance Order Tables
+	$table_name   = $wpdb->prefix . 'wc_orders_meta';
+	$hpos_enabled = $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $table_name ) ) === $table_name;
+
+	foreach ( $related_order_cache_keys as $cache_key ) {
+		if ( $hpos_enabled ) {
+			$wpdb->delete(
+				$table_name,
+				array( 'meta_key' => $cache_key ),
+				array( '%s' )
+			);
+		} else {
+			delete_metadata( 'post', null, $cache_key, '', true );
+		}
+	}
+
+	// Set option so this function doesn't run again.
+	update_option( 'safety_net_caches_deleted', true );
+
+	wp_cache_flush();
+}

--- a/includes/delete-related-order-caches.php
+++ b/includes/delete-related-order-caches.php
@@ -27,6 +27,10 @@ function delete_all_subscription_caches() {
 	// Delete from wp_usermeta
 	delete_metadata( 'user', null, $customer_cache_key, '', true );
 
+	// Check if HPOS tables exists
+	$table_name   = $wpdb->prefix . 'wc_orders_meta';
+	$hpos_exists  = $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $table_name ) ) === $table_name;
+
 	// 2. Delete related order caches
 	$related_order_cache_keys = array(
 		'_subscription_renewal_order_ids_cache',
@@ -34,20 +38,22 @@ function delete_all_subscription_caches() {
 		'_subscription_resubscribe_order_ids_cache',
 	);
 
-	// Delete data from the High Performance Order Tables
-	$table_name   = $wpdb->prefix . 'wc_orders_meta';
-	$hpos_enabled = $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $table_name ) ) === $table_name;
+	$placeholders = implode( ', ', array_fill( 0, count( $related_order_cache_keys ), '%s' ) );
 
-	foreach ( $related_order_cache_keys as $cache_key ) {
-		if ( $hpos_enabled ) {
-			$wpdb->delete(
-				$table_name,
-				array( 'meta_key' => $cache_key ),
-				array( '%s' )
-			);
-		} else {
-			delete_metadata( 'post', null, $cache_key, '', true );
-		}
+	$wpdb->query(
+		$wpdb->prepare(
+			"DELETE FROM {$wpdb->postmeta} WHERE meta_key IN ($placeholders)", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+			...$related_order_cache_keys
+		)
+	);
+
+	if ( $hpos_exists ) {
+		$wpdb->query(
+			$wpdb->prepare(
+				"DELETE FROM {$table_name} WHERE meta_key IN ($placeholders)", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+				...$related_order_cache_keys
+			)
+		);
 	}
 
 	// Set option so this function doesn't run again.

--- a/safety-net.php
+++ b/safety-net.php
@@ -36,6 +36,7 @@ require_once __DIR__ . '/includes/admin.php';
 require_once __DIR__ . '/includes/bootstrap.php';
 require_once __DIR__ . '/includes/common.php';
 require_once __DIR__ . '/includes/delete.php';
+require_once __DIR__ . '/includes/delete-related-order-caches.php';
 require_once __DIR__ . '/includes/delete-transients.php';
 require_once __DIR__ . '/includes/deactivate-plugins.php';
 require_once __DIR__ . '/includes/scrub-options.php';


### PR DESCRIPTION
This function will delete WooCommerce Subscriptions related order and customer cache.

Created a new file and action to handle this type of deletion.

### Testing instructions

You can test this with a store with some subscriptions and caches created. There's a cache generation tool if you go to `WooCommerce > Status > Tools`. You can check the cache meta if HPOS is enabled on: `wc_orders_meta` table. The keys deleted are:

- Switch Orders: `_subscription_switch_order_ids_cache`.
- Renewal Orders: `_subscription_renewal_order_ids_cache`.
- Resubscribe Orders: `_subscription_resubscribe_order_ids_cache`.
- Customer Subscription cache: `_wcs_subscription_ids_cache`.

See: https://woocommerce.com/document/subscriptions/develop/cache/

Mentions #41.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic clearing of subscription- and order-related caches on non-production (staging/dev/local) environments.
  * Support for High Performance Order Tables (HPOS) when removing related order caches.
  * Improved multisite handling so customer and user cache keys are cleared per site.
  * Ensures cache-clearing runs once by recording completion to avoid repeated deletions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->