### PR TITLE
Disable TikTok for Business

### DIFF
--- a/assets/data/plugin_denylist.txt
+++ b/assets/data/plugin_denylist.txt
@@ -34,6 +34,7 @@ smtp
 socketlabs
 sparkpost
 stripe
+tiktok-for-business
 webgility
 wc-cashapp
 woocommerce-zapier

--- a/safety-net.php
+++ b/safety-net.php
@@ -3,7 +3,7 @@
  * Plugin Name: Safety Net
  * Plugin URI: https://specialprojects.automattic.com/tools/safety-net/
  * Description: For Team51 Development Sites. Deletes user data and more!
- * Version: 1.5.6
+ * Version: 1.5.7
  * Author: WordPress.com Special Projects
  * Author URI: https://specialprojects.automattic.com
  * Text Domain: safety-net


### PR DESCRIPTION
This adds TikTok for Business to the denylist which should prevent products from being synced back to TikTok store.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Updated to version 1.5.7
* Updated plugin blocklist

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->