### PR TITLE
Fix robots_txt hook to use filter instead of action (Rank Math conflict)

### DIFF
--- a/includes/common.php
+++ b/includes/common.php
@@ -15,9 +15,8 @@ add_filter(
 
 // Discourage search engines from indexing the site and disallow the entire site in robots.txt.
 add_filter( 'option_blog_public', '__return_zero' );
-add_action( 'robots_txt', __NAMESPACE__ . '\disallow_all_user_agents' );
+add_filter( 'robots_txt', __NAMESPACE__ . '\disallow_all_user_agents' );
 
-function disallow_all_user_agents() {
-	echo 'User-agent: *' . PHP_EOL;
-	echo 'Disallow: /' . PHP_EOL;
+function disallow_all_user_agents( $output ) {
+	return "User-agent: *\nDisallow: /\n";
 }


### PR DESCRIPTION
Fixes a conflict between Safety Net and Rank Math SEO that caused `User-agent: *\nDisallow: /` to leak into admin responses, breaking `admin-ajax` requests on staging sites (originally reported on Nova Ukraine's staging site).

## Root cause

`robots_txt` is a WordPress **filter** — `apply_filters( 'robots_txt', $output, $public )` — but Safety Net was registering it with `add_action` and `echo`ing the output:

```php
add_action( 'robots_txt', __NAMESPACE__ . '\disallow_all_user_agents' );

function disallow_all_user_agents() {
    echo 'User-agent: *' . PHP_EOL;
    echo 'Disallow: /' . PHP_EOL;
}
```

This works fine on the actual `/robots.txt` request, but any plugin that invokes `apply_filters( 'robots_txt', ... )` outside that context (like Rank Math previewing robots.txt content in its admin settings) would trigger the echo, dumping raw text into the response body. For `admin-ajax.php` calls, that corrupts the JSON/text response and breaks features like async plugin activation, menu editing, etc.

## Fix

Switch to `add_filter` and return the disallow string instead of echoing it. Behavior on `/robots.txt` is unchanged (the returned value replaces the default output, which is what we want), and the function no longer pollutes responses when other plugins call the filter.

```php
add_filter( 'robots_txt', __NAMESPACE__ . '\disallow_all_user_agents' );

function disallow_all_user_agents( $output ) {
    return "User-agent: *\nDisallow: /\n";
}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the robots.txt generation mechanism for improved WordPress integration compatibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/a8cteam51/safety-net/pull/182)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->