### PR TITLE
Add safety-net/v1/status REST endpoint

### DIFF
--- a/includes/rest-status.php
+++ b/includes/rest-status.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace SafetyNet\RestStatus;
+
+use function SafetyNet\Utilities\get_environment_type;
+
+add_action( 'rest_api_init', __NAMESPACE__ . '\register_status_route' );
+
+/**
+ * Registers the read-only status route used to confirm, over HTTP, that Safety Net has run.
+ */
+function register_status_route() {
+	register_rest_route(
+		'safety-net/v1',
+		'/status',
+		array(
+			'methods'             => \WP_REST_Server::READABLE,
+			'permission_callback' => '__return_true',
+			'callback'            => __NAMESPACE__ . '\get_status',
+		)
+	);
+}
+
+/**
+ * Reports Safety Net's run state: the environment plus each scrub step's completion flag.
+ *
+ * This file only loads on non-production sites (safety-net.php bails before requiring it on production), so the
+ * route's mere presence already signals Safety Net is active here. It is meant to be polled until the scrub
+ * completes, so the response must never be cached: a stale snapshot would keep reporting a step as undone after
+ * it had finished. DONOTCACHEPAGE covers page caches (Batcache, host edge); the headers cover proxies/CDNs.
+ */
+function get_status() {
+	if ( ! defined( 'DONOTCACHEPAGE' ) ) {
+		define( 'DONOTCACHEPAGE', true );
+	}
+
+	$response = new \WP_REST_Response(
+		array(
+			'active'              => true,
+			'environment'         => get_environment_type(),
+			'options_scrubbed'    => (bool) get_option( 'safety_net_options_scrubbed' ),
+			'plugins_deactivated' => (bool) get_option( 'safety_net_plugins_deactivated' ),
+			'data_deleted'        => (bool) get_option( 'safety_net_data_deleted' ),
+			'transients_deleted'  => (bool) get_option( 'safety_net_transients_deleted' ),
+			'webhooks_disabled'   => (bool) get_option( 'safety_net_webhooks_disabled' ),
+		)
+	);
+
+	$response->header( 'Cache-Control', 'no-store, no-cache, must-revalidate, max-age=0' );
+	$response->header( 'Pragma', 'no-cache' );
+	$response->header( 'Expires', 'Wed, 11 Jan 1984 05:00:00 GMT' );
+
+	return $response;
+}

--- a/safety-net.php
+++ b/safety-net.php
@@ -3,7 +3,7 @@
  * Plugin Name: Safety Net
  * Plugin URI: https://specialprojects.automattic.com/tools/safety-net/
  * Description: For Team51 Development Sites. Deletes user data and more!
- * Version: 1.5.8
+ * Version: 1.6.0
  * Author: WordPress.com Special Projects
  * Author URI: https://specialprojects.automattic.com
  * Text Domain: safety-net
@@ -40,6 +40,7 @@ require_once __DIR__ . '/includes/delete-transients.php';
 require_once __DIR__ . '/includes/deactivate-plugins.php';
 require_once __DIR__ . '/includes/scrub-options.php';
 require_once __DIR__ . '/includes/disable-webhooks.php';
+require_once __DIR__ . '/includes/rest-status.php';
 
 if ( defined( 'WP_CLI' ) && WP_CLI ) {
 	require_once __DIR__ . '/includes/classes/cli/class-safetynet-cli.php';


### PR DESCRIPTION
## Summary

- Adds a read-only REST route `GET /wp-json/safety-net/v1/status` reporting Safety Net's run state: `environment` plus the existing per-step completion flags (`options_scrubbed`, `plugins_deactivated`, `data_deleted`, `transients_deleted`, `webhooks_disabled`).
- Lets external tooling confirm over HTTP — no shell/SSH, no webhook — that the scrub actually ran on a clone, not just that the plugin files are present.
- Non-production only: registered alongside the other includes (after the production bail), so the route exists only where Safety Net is active; production returns 404. New file `includes/rest-status.php`.
- Marks the response uncacheable (`DONOTCACHEPAGE` + `Cache-Control: no-store, no-cache` / `Pragma` / `Expires`) since it's meant to be polled until the scrub completes — a cached snapshot would report a step as undone after it finished.
- Introduces no new state; only reads the `safety_net_*` options the scrub already sets. Bumps 1.5.8 → 1.6.0.

## Notes

- Public read (`permission_callback => __return_true`): payload is booleans + environment string only, no site data. Can be token-gated if preferred.
- Motivation: an orchestrator (Poseidon/OpsOasis) provisions staging clones and must confirm the data purge before using them. Today that confirmation rides a single Pressable `ssh_command` webhook with no fallback, so a lost webhook strands the clone. Polling this endpoint is webhook-independent — and the poll itself boots WP, firing `safety_net_loaded` and the scrub.

## Test plan

- [ ] Staging/dev/local with Safety Net active: `curl https://<site>/wp-json/safety-net/v1/status` → 200 JSON with `active:true`, `environment`, and the five flags.
- [ ] After the first front-end load, `data_deleted` and `options_scrubbed` report `true`.
- [ ] `curl -sI` shows `Cache-Control: no-store, no-cache, must-revalidate`.
- [ ] Production site: route returns 404 (plugin inert).
- [ ] `php -l` clean on `safety-net.php` and `includes/rest-status.php`.
