### PR TITLE
fix: declare $before_date as explicitly nullable in claim_actions()

### DIFF
--- a/includes/classes/class-actionscheduler-custom-dbstore.php
+++ b/includes/classes/class-actionscheduler-custom-dbstore.php
@@ -7,7 +7,7 @@ use RuntimeException;
 
 class ActionScheduler_Custom_DBStore extends \ActionScheduler_DBStore {
 
-	protected function claim_actions( $claim_id, $limit, \DateTime $before_date = null, $hooks = array(), $group = '' ): int {
+	protected function claim_actions( $claim_id, $limit, ?\DateTime $before_date = null, $hooks = array(), $group = '' ): int {
 
 		/** @var \wpdb $wpdb */
 		global $wpdb;

--- a/safety-net.php
+++ b/safety-net.php
@@ -3,7 +3,7 @@
  * Plugin Name: Safety Net
  * Plugin URI: https://specialprojects.automattic.com/tools/safety-net/
  * Description: For Team51 Development Sites. Deletes user data and more!
- * Version: 1.6.0
+ * Version: 1.6.1
  * Author: WordPress.com Special Projects
  * Author URI: https://specialprojects.automattic.com
  * Text Domain: safety-net


### PR DESCRIPTION
## What

Adds `?` to the `$before_date` parameter of `ActionScheduler_Custom_DBStore::claim_actions()`:

```diff
- protected function claim_actions( $claim_id, $limit, \DateTime $before_date = null, $hooks = array(), $group = '' ): int {
+ protected function claim_actions( $claim_id, $limit, ?\DateTime $before_date = null, $hooks = array(), $group = '' ): int {
```

Also bumps the plugin header version `1.6.0` → `1.6.1` (patch).

## Why

Implicitly marking a typed parameter as nullable (a non-nullable type hint with a `null` default) is **deprecated as of PHP 8.4** and emits an `E_DEPRECATED` notice. Because `safety-net` is a must-use plugin and this override runs on every Action Scheduler queue claim on dev/staging clones, the notice fires frequently once a site moves to PHP 8.4/8.5.

Flagged by PHPCompatibility (`PHPCompatibility.FunctionDeclarations.RemovedImplicitlyNullableParam`) at `testVersion 8.5`. It is the only PHP 8.5 finding in the plugin.

## Compatibility / risk

- **No behavior change** — an implicitly-nullable parameter already accepts `null`; this just declares it explicitly.
- Keeps the override signature-compatible with the parent `\ActionScheduler_DBStore::claim_actions()`, which already declares `?DateTime` in current Action Scheduler.
- Explicit nullable type syntax (`?Type`) is valid since PHP 7.1, so it is safe across the plugin's supported PHP range.

## Testing

- `php -l` — no syntax errors.
- PHPCompatibility `--standard=PHPCompatibilityWP --runtime-set testVersion 8.5` on the file: **1 warning before → 0 after**.
