### PR TITLE
Prevents Safety Net from running during WordPress installation

### DIFF
--- a/safety-net.php
+++ b/safety-net.php
@@ -19,7 +19,7 @@ if ( defined( 'SAFETY_NET_PATH' ) ) {
 }
 
 if ( wp_installing() && ! is_blog_installed() ) {
-	return; // Return if WordPress is installing
+	return; // Bail during core installation — the database isn't ready yet.
 }
 
 define( 'SAFETY_NET_PATH', plugin_dir_path( __FILE__ ) );

--- a/safety-net.php
+++ b/safety-net.php
@@ -18,7 +18,7 @@ if ( defined( 'SAFETY_NET_PATH' ) ) {
 	return; // Return if another copy of the plugin is activated
 }
 
-if ( wp_installing() ) {
+if ( wp_installing() && ! is_blog_installed() ) {
 	return; // Return if WordPress is installing
 }
 

--- a/safety-net.php
+++ b/safety-net.php
@@ -18,6 +18,10 @@ if ( defined( 'SAFETY_NET_PATH' ) ) {
 	return; // Return if another copy of the plugin is activated
 }
 
+if ( wp_installing() ) {
+	return; // Return if WordPress is installing
+}
+
 define( 'SAFETY_NET_PATH', plugin_dir_path( __FILE__ ) );
 define( 'SAFETY_NET_URL', plugin_dir_url( __FILE__ ) );
 define( 'SAFETY_NET_BASENAME', plugin_basename( __FILE__ ) );


### PR DESCRIPTION
## Summary

Prevents Safety Net from running during WordPress core installation when loaded as an mu-plugin.

## What changed

- Added an early return in `safety-net.php` when `wp\_installing()` is true.
- This skips Safety Net bootstrap/actions during `/wp-admin/install.php`.

## Why

During install, Safety Net could run its workflow too early and return:

`Safety Net Error: options need to be scrubbed first.`

That blocks the installation flow.

Fixes #187